### PR TITLE
Render markdown headings in partials

### DIFF
--- a/layouts/partials/contact-ctx.html
+++ b/layouts/partials/contact-ctx.html
@@ -8,7 +8,7 @@
 <section class="contact bg-gold">
   <div class="container contact-wrapper">
     <div>
-      <h2>{{.ctx.heading}}</h2>
+      <h2>{{.ctx.heading | markdownify | replaceRE "^<p>(.*)</p>$" "$1" | safeHTML}}</h2>
       <p>{{.ctx.text | markdownify}}</p>
     </div>
   </div>

--- a/layouts/partials/l_r.html
+++ b/layouts/partials/l_r.html
@@ -2,8 +2,8 @@
   <div class="container mx-auto">
     <div style="{{if .ctx.reverse}}flex-direction: row-reverse;{{end}}" class="l-r-wrapper">
       <div class="left">
-        <h2 id="{{.ctx.heading | urlize}}" style="color: {{.ctx.color}}; text-decoration:underline;">{{.ctx.heading}}</h2>
-        <h4>{{.ctx.subheading}}</h4>
+        <h2 id="{{.ctx.heading | urlize}}" style="color: {{.ctx.color}}; text-decoration:underline;">{{.ctx.heading | markdownify | replaceRE "^<p>(.*)</p>$" "$1" | safeHTML}}</h2>
+        <h4>{{.ctx.subheading | markdownify | replaceRE "^<p>(.*)</p>$" "$1" | safeHTML}}</h4>
         <div style="color: {{.ctx.color}};">{{ index (split .content "<hr>") .ctx.order | markdownify }}</div>
        <div class="mt-2">
           <a class="btn-underlined" href="{{.ctx.cta_link}}">{{.ctx.cta}}</a>


### PR DESCRIPTION
## Summary
- render headings in layout partials through `markdownify` so markdown formatting displays correctly
- strip default paragraph wrappers while keeping existing ids and attributes intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929a9c2bda08320bc693786f0696cdd)