### PR TITLE
Add blog landing page

### DIFF
--- a/assets/sass/_blog.scss
+++ b/assets/sass/_blog.scss
@@ -1,0 +1,78 @@
+.blog {
+  .hero-alt {
+    min-height: 380px;
+  }
+}
+
+.blog-list-section {
+  background: #F1F7F5;
+
+  .blog-list-header {
+    max-width: 780px;
+    margin: 0 auto 2.5rem;
+
+    .eyebrow {
+      font-size: 0.9rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+
+    h2 {
+      font-size: clamp(1.75rem, 3vw, 2.25rem);
+      margin-bottom: 0.5rem;
+    }
+
+    .text-p {
+      color: #334B4E;
+      font-size: 1.05rem;
+    }
+  }
+
+  .blog-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .blog-card {
+    background: #fff;
+    border: 1px solid #dce6e2;
+    border-radius: 14px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    h3 {
+      margin: 0;
+      font-size: 1.25rem;
+      color: #1e1e1e;
+    }
+
+    .blog-card__meta {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.95rem;
+      color: #4B7A81;
+      margin: 0;
+
+      time {
+        font-weight: 700;
+      }
+
+      .blog-card__author {
+        font-weight: 600;
+      }
+    }
+
+    .blog-card__description {
+      margin: 0;
+      color: #334B4E;
+      line-height: 1.6;
+    }
+  }
+}

--- a/assets/sass/_new.scss
+++ b/assets/sass/_new.scss
@@ -256,6 +256,7 @@ body{
 
 .text-light{ color: #fff; }
 .text-dark{ color: #000; }
+.text-primary{ color: #334B4E; }
 .text-center{ text-align: center; }
 .text-gold{ color: #D9C78E; }
 // bg

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -1,4 +1,5 @@
 @import 'about';
+@import 'blog';
 @import 'clients';
 @import 'contact';
 @import 'generic';

--- a/config.toml
+++ b/config.toml
@@ -20,6 +20,10 @@ copyright = '© {year} Flax & Teal Limited.'
     pageRef = '/products'
     weight = 30
   [[menus.main]]
+    name = 'Blog'
+    pageRef = '/blog'
+    weight = 35
+  [[menus.main]]
     name = 'Clients'
     pageRef = '/clients'
     weight = 40

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Blog"
+date: 2024-08-22T00:00:00Z
+draft: false
+aliases: ['/blog']
+sections:
+  - type: hero-alt
+    text_color: 'light'
+    bg_color: '#334B4E'
+    bg_image: '/images/index/header-bg.webp'
+    heading: 'Flax & Teal Blog'
+    text: 'News, ideas, and lessons learned from building open technology and data-driven products.'
+  - type: blog-list
+    intro_heading: 'Latest posts'
+    intro_text: "Explore what our team is thinking about product delivery, open standards, and applied data science."
+    posts:
+      - title: 'Turning open data into operational insight'
+        author: 'Alex Smith'
+        date: '2024-07-10T00:00:00Z'
+        description: 'A walkthrough of how we streamline public datasets, enrich them with domain models, and ship analysis tools that teams can rely on every day.'
+      - title: 'Designing reliable data products for civic teams'
+        author: 'Priya Das'
+        date: '2024-06-18T00:00:00Z'
+        description: 'Practical guidance on combining UX research, geospatial visualisation, and cloud infrastructure to keep stakeholders aligned.'
+      - title: 'Shipping faster with reusable simulation components'
+        author: 'Sam O’Neill'
+        date: '2024-05-30T00:00:00Z'
+        description: 'Why we invest in openly-licensed building blocks for physics simulations and how that accelerates collaborative delivery.'
+---

--- a/layouts/partials/blog-list.html
+++ b/layouts/partials/blog-list.html
@@ -1,0 +1,31 @@
+<section class="blog-list-section py-5 px-2">
+  <div class="container">
+    <div class="blog-list-header">
+      <p class="eyebrow text-primary">{{ default "Blog" .label }}</p>
+      <h2>{{ .intro_heading | default "Latest posts" | markdownify }}</h2>
+      {{ with .intro_text }}
+      <p class="text-p">{{ . | markdownify }}</p>
+      {{ end }}
+    </div>
+
+    {{ with .posts }}
+    <div class="blog-grid">
+      {{ range . }}
+      <article class="blog-card">
+        <p class="blog-card__meta">
+          {{ with .date }}
+          <time datetime="{{ . }}">{{ time . | time.Format "2 Jan 2006" }}</time>
+          {{ end }}
+          {{ if and .date .author }}<span aria-hidden="true">•</span>{{ end }}
+          {{ with .author }}<span class="blog-card__author">{{ . }}</span>{{ end }}
+        </p>
+        <h3>{{ .title | markdownify }}</h3>
+        {{ with .description }}
+        <p class="blog-card__description">{{ . | markdownify }}</p>
+        {{ end }}
+      </article>
+      {{ end }}
+    </div>
+    {{ end }}
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a blog landing page with hero messaging and sample post metadata
- introduce a reusable blog list partial and scoped styling for author/date/details
- link the new page from the main navigation so it is reachable from the header

## Testing
- Not run (tooling unavailable): `hugo --minify`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bce45ea688320bc617720e760b65f)