### PR TITLE
Add GitHub-driven blog publishing workflow

### DIFF
--- a/.github/workflows/publish-blog.yml
+++ b/.github/workflows/publish-blog.yml
@@ -1,0 +1,139 @@
+name: Publish Blog Post
+
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: "Post title"
+        required: true
+        type: string
+      author:
+        description: "Author name"
+        required: true
+        type: string
+      summary:
+        description: "1-2 sentence summary for the listing page"
+        required: true
+        type: string
+      body:
+        description: "Full post body (Markdown)"
+        required: true
+        type: string
+      tags:
+        description: "Optional comma-separated tags"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-post:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate post
+        env:
+          TITLE: ${{ inputs.title }}
+          AUTHOR: ${{ inputs.author }}
+          SUMMARY: ${{ inputs.summary }}
+          BODY: ${{ inputs.body }}
+          TAGS: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${TITLE}" || -z "${AUTHOR}" || -z "${SUMMARY}" || -z "${BODY}" ]]; then
+            echo "All required fields (title, author, summary, body) must be provided."
+            exit 1
+          fi
+
+          DATE_UTC="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          DATE_PREFIX="${DATE_UTC%%T}"
+
+          SLUG="$(python - <<'PY'
+import os, re, sys, unicodedata
+title = os.environ["TITLE"]
+value = unicodedata.normalize("NFKD", title).encode("ascii", "ignore").decode("ascii")
+value = re.sub(r"[^a-zA-Z0-9]+", "-", value).strip("-").lower()
+print(value or "post")
+PY
+)"
+
+          export TAG_LIST="[]"
+          if [[ -n "${TAGS}" ]]; then
+            export TAG_LIST="$(python - <<'PY'
+import os, json
+tags = [t.strip() for t in os.environ["TAGS"].split(",") if t.strip()]
+print(json.dumps(tags))
+PY
+)"
+          fi
+
+          export POST_PATH="content/blog/${DATE_PREFIX}-${SLUG}.md"
+
+          python - <<'PY'
+import json, os, pathlib
+
+post = {
+    "title": os.environ["TITLE"],
+    "date": os.environ["DATE_UTC"],
+    "author": os.environ["AUTHOR"],
+    "description": os.environ["SUMMARY"],
+    "draft": False,
+    "tags": json.loads(os.environ["TAG_LIST"]),
+}
+
+body = os.environ["BODY"]
+path = pathlib.Path(os.environ["POST_PATH"])
+
+front_matter = "\n".join(
+    [
+        f'title: {json.dumps(post["title"])}',
+        f'date: {post["date"]}',
+        f'author: {json.dumps(post["author"])}',
+        f'description: {json.dumps(post["description"])}',
+        f'draft: {str(post["draft"]).lower()}',
+        f'tags: {json.dumps(post["tags"])}',
+    ]
+)
+
+content = f"---\n{front_matter}\n---\n\n{body.strip()}\n"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(content, encoding="utf-8")
+PY
+
+          echo "Created ${POST_PATH}"
+          echo "post_path=${POST_PATH}" >> "$GITHUB_ENV"
+
+      - name: Commit and push
+        env:
+          POST_PATH: ${{ env.post_path }}
+          TITLE: ${{ inputs.title }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add "${POST_PATH}"
+          git commit -m "Add blog post: ${TITLE}"
+          git push origin HEAD:${{ github.ref_name }}
+
+      - name: Workflow summary
+        env:
+          POST_PATH: ${{ env.post_path }}
+          TITLE: ${{ inputs.title }}
+          AUTHOR: ${{ inputs.author }}
+          SUMMARY: ${{ inputs.summary }}
+        run: |
+          {
+            echo "### Blog post created"
+            echo "- File: \`${POST_PATH}\`"
+            echo "- Title: \"${TITLE}\""
+            echo "- Author: ${AUTHOR}"
+            echo "- Summary: ${SUMMARY}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -18,3 +18,17 @@ form_action_endpoint = 'https://submit-form.com/xxxxxxxxx'
 ## Converting from png to webp
 
 Currently done by `mogrify -format webp -quality 80 X.png` with ImageMagick installed.
+
+## Publishing blog posts (staff-only portal)
+
+Flax & Teal staff can publish new blog posts through GitHub:
+
+1. Open the repository in GitHub and go to **Actions → Publish Blog Post**.
+2. Click **Run workflow** and fill in:
+   - **Title** and **Author** (required).
+   - **Summary** for the listing card (1–2 sentences, required).
+   - **Body** with the full Markdown content (required).
+   - **Tags** (comma-separated, optional).
+3. Submit the form. The workflow will create a new Markdown file in `content/blog/`, commit it to `master`, and the existing deploy workflow will publish it to `/blog`.
+
+Only users with write access to the repository (F&T staff) can run the workflow, keeping the publishing portal private to the team.

--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,10 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+author: ""
+description: ""
+draft: false
+tags: []
+---
+
+Write your post content here.

--- a/assets/sass/_blog.scss
+++ b/assets/sass/_blog.scss
@@ -50,6 +50,15 @@
       margin: 0;
       font-size: 1.25rem;
       color: #1e1e1e;
+
+      a {
+        color: inherit;
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
 
     .blog-card__meta {
@@ -73,6 +82,27 @@
       margin: 0;
       color: #334B4E;
       line-height: 1.6;
+    }
+  }
+}
+
+.blog.single-content {
+  .hero_single {
+    .blog-meta {
+      color: #4B7A81;
+      font-size: 1rem;
+      margin: 0.5rem 0 0;
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+
+      time {
+        font-weight: 700;
+      }
+
+      .blog-card__author {
+        font-weight: 600;
+      }
     }
   }
 }

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -13,17 +13,5 @@ sections:
   - type: blog-list
     intro_heading: 'Latest posts'
     intro_text: "Explore what our team is thinking about product delivery, open standards, and applied data science."
-    posts:
-      - title: 'Turning open data into operational insight'
-        author: 'Alex Smith'
-        date: '2024-07-10T00:00:00Z'
-        description: 'A walkthrough of how we streamline public datasets, enrich them with domain models, and ship analysis tools that teams can rely on every day.'
-      - title: 'Designing reliable data products for civic teams'
-        author: 'Priya Das'
-        date: '2024-06-18T00:00:00Z'
-        description: 'Practical guidance on combining UX research, geospatial visualisation, and cloud infrastructure to keep stakeholders aligned.'
-      - title: 'Shipping faster with reusable simulation components'
-        author: 'Sam O’Neill'
-        date: '2024-05-30T00:00:00Z'
-        description: 'Why we invest in openly-licensed building blocks for physics simulations and how that accelerates collaborative delivery.'
+    limit: 12
 ---

--- a/content/blog/publishing-workflow.md
+++ b/content/blog/publishing-workflow.md
@@ -1,0 +1,24 @@
+---
+title: "Publishing blog posts with GitHub"
+date: 2024-08-22T00:00:00Z
+author: "Flax & Teal"
+description: "Introducing the staff-only GitHub portal for adding new articles to the Flax & Teal blog."
+draft: false
+tags: ["workflow", "content"]
+---
+
+Our blog now publishes directly from GitHub. Instead of editing site files manually, Flax & Teal staff can run the **Publish Blog Post** workflow in GitHub and fill out a short form. The workflow will create a new Markdown file in `content/blog`, commit it to the repository, and trigger the normal site deployment pipeline.
+
+### How the workflow works
+
+1. Go to **Actions → Publish Blog Post → Run workflow** in GitHub.
+2. Enter the post **Title**, **Author**, and a short **Summary** (used on the listing page).
+3. Paste the full Markdown **Body** of the article, plus optional comma-separated **Tags**.
+4. Run the workflow. When it finishes, a new post file is committed to `master` and will appear on the `/blog` page after the next deploy.
+
+### Tips for great posts
+
+- Use Markdown headings to structure your article.
+- Add links with `[text](url)` and bullet lists for readability.
+- Keep summaries to ~1–2 sentences; they’re shown on the blog listing cards.
+- Include a publish-ready title case headline so the URL slug reads well.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,7 +3,12 @@
 
 <main class="{{.RelPermalink | humanize | urlize}}">
   {{ range .Params.sections }}
-  {{ partial (printf "%s.html" .type) . }}
+  {{ $partial := printf "%s.html" .type }}
+  {{ if eq .type "blog-list" }}
+  {{ partial $partial (dict "section" . "page" $) }}
+  {{ else }}
+  {{ partial $partial . }}
+  {{ end }}
   {{ end }}
 </main>
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,19 @@
 {{ define "main" }}
 {{ partial "nav-new.html" . }}
 
-<main class="{{.RelPermalink | humanize | urlize}} single-content">
+<main class="{{.RelPermalink | humanize | urlize}} single-content {{ .Type }}">
     <section class="hero_single">
       <h1>{{.Title | markdownify}}</h1>
+      {{ if eq .Type "blog" }}
+      <p class="blog-meta">
+        {{ with .Date }}
+        <time datetime="{{ . }}">{{ . | time.Format "2 Jan 2006" }}</time>
+        {{ end }}
+        {{ if and .Date .Params.author }}<span aria-hidden="true">•</span>{{ end }}
+        {{ with .Params.author }}<span class="blog-card__author">{{ . }}</span>{{ end }}
+        {{ if gt .ReadingTime 0 }}<span aria-hidden="true">•</span><span>{{ .ReadingTime }} min read</span>{{ end }}
+      </p>
+      {{ end }}
       {{with .Params.subtitle}}
       <p>{{. | markdownify}}</p>
       {{end}}

--- a/layouts/partials/blog-list.html
+++ b/layouts/partials/blog-list.html
@@ -1,31 +1,49 @@
+{{ $section := .section }}
+{{ $page := .page }}
+{{ $posts := slice }}
+
+{{ with $page }}
+  {{ $posts = where .RegularPages "Draft" "!=" true | sort "Date" "desc" }}
+{{ end }}
+
+{{ if $section.limit }}
+  {{ $posts = first $section.limit $posts }}
+{{ end }}
+
 <section class="blog-list-section py-5 px-2">
   <div class="container">
     <div class="blog-list-header">
-      <p class="eyebrow text-primary">{{ default "Blog" .label }}</p>
-      <h2>{{ .intro_heading | default "Latest posts" | markdownify }}</h2>
-      {{ with .intro_text }}
+      <p class="eyebrow text-primary">{{ default "Blog" $section.label }}</p>
+      <h2>{{ $section.intro_heading | default "Latest posts" | markdownify }}</h2>
+      {{ with $section.intro_text }}
       <p class="text-p">{{ . | markdownify }}</p>
       {{ end }}
     </div>
 
-    {{ with .posts }}
+    {{ if gt (len $posts) 0 }}
     <div class="blog-grid">
-      {{ range . }}
+      {{ range $posts }}
       <article class="blog-card">
         <p class="blog-card__meta">
-          {{ with .date }}
-          <time datetime="{{ . }}">{{ time . | time.Format "2 Jan 2006" }}</time>
+          {{ with .Date }}
+          <time datetime="{{ . }}">{{ . | time.Format "2 Jan 2006" }}</time>
           {{ end }}
-          {{ if and .date .author }}<span aria-hidden="true">•</span>{{ end }}
-          {{ with .author }}<span class="blog-card__author">{{ . }}</span>{{ end }}
+          {{ if and .Date .Params.author }}<span aria-hidden="true">•</span>{{ end }}
+          {{ with .Params.author }}<span class="blog-card__author">{{ . }}</span>{{ end }}
         </p>
-        <h3>{{ .title | markdownify }}</h3>
-        {{ with .description }}
+        <h3><a href="{{ .RelPermalink }}">{{ .Title | markdownify }}</a></h3>
+        {{ with .Params.description }}
         <p class="blog-card__description">{{ . | markdownify }}</p>
+        {{ else }}
+        {{ with .Summary }}
+        <p class="blog-card__description">{{ . | plainify }}</p>
+        {{ end }}
         {{ end }}
       </article>
       {{ end }}
     </div>
+    {{ else }}
+    <p class="text-center text-muted">No posts published yet.</p>
     {{ end }}
   </div>
 </section>


### PR DESCRIPTION
## Summary
- add a GitHub Actions "Publish Blog Post" workflow that lets F&T staff create new posts through a protected GitHub form
- switch the blog listing to render published markdown posts, add a blog archetype, and include a launch article covering the workflow
- refine blog styling/metadata and document the publishing portal in the README

## Testing
- `hugo --minify` *(fails: command not found in runner)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bdce5aba08320ab4574c7345c0326)