### PR TITLE
Disable blog page and remove menu link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,10 +20,6 @@ copyright = '© {year} Flax & Teal Limited.'
     pageRef = '/products'
     weight = 30
   [[menus.main]]
-    name = 'Blog'
-    pageRef = '/blog'
-    weight = 35
-  [[menus.main]]
     name = 'Clients'
     pageRef = '/clients'
     weight = 40

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Blog"
 date: 2024-08-22T00:00:00Z
-draft: false
+draft: true
 aliases: ['/blog']
 sections:
   - type: hero-alt


### PR DESCRIPTION
### Motivation
- Temporarily disable publication of the blog landing page while keeping the source content in the repository.
- Prevent the Blog navigation item from being displayed in the main site menu to remove public access.
- Bundle the changes for review and inclusion via a pull request.

### Description
- Set `draft: true` in `content/blog/_index.md` to prevent the blog landing page from being published.
- Removed the `[[menus.main]]` block for the Blog entry in `config.toml` to hide the menu link.
- Staged and committed the changes with `git commit -m "Disable blog page and hide menu link"` and prepared a PR titled `Disable blog page and hide menu link`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d2ec945448320b1f88dbc839e6734)