### PR TITLE
Refine Grover's Algorithm guide to mirror notebook and add diagrams

### DIFF
--- a/content/grovers-algorithm-guide/_index.md
+++ b/content/grovers-algorithm-guide/_index.md
@@ -1,0 +1,161 @@
+---
+title: "Grover's Algorithm Guide"
+slug: "grovers-algorithm-guide"
+draft: false
+layout: "single"
+description: "A step-by-step walkthrough of Grover's quantum search algorithm, including the oracle, diffusion operator, and amplitude amplification schedule."
+---
+
+## Introduction
+
+Grover's algorithm is an algorithm to perform search on an unordered list. Ordered lists can be searched efficiently using [binary search][binary-search], but classically an unordered list requires \(O(N)\) checks. Grover's algorithm reduces this to \(O(\sqrt{N})\) operations—often not enough for quantum advantage, but crucial as an amplitude-amplification subroutine and for its educational simplicity.
+
+**Problem statement**: Given an unordered list of values, return the index (position) of the element that satisfies a criterion (the function to test this criterion is called an oracle).
+
+**Algorithm Outline**: Prepare a superposition over every index and repeatedly apply an operation that amplifies the amplitude of the marked index until it dominates the output, in \(O(\sqrt{N})\) applications.
+
+**Need for an efficient and useful oracle**: The oracle identifies the state of interest. Many toy derivations assume knowledge of the result, but the algorithm also works with a realistic oracle. See [oracle][oracle] for current proposals.
+
+## Algorithm Outline
+
+See the [IBM tutorial](https://quantum.cloud.ibm.com/docs/en/tutorials/grovers-algorithm) for complementary details; this guide focuses on the mathematical derivation of the computational complexity.
+
+We start with the uniform superposition
+
+$$
+|s\rangle = \frac{1}{\sqrt{N}}\sum_{x=0}^{N-1}|x\rangle.
+$$
+
+Rewrite it using the target state \(|\omega\rangle\) and its orthogonal complement
+
+$$
+|\omega_\perp\rangle = \frac{1}{\sqrt{N-1}}\sum_{x\neq \omega}|x\rangle.
+$$
+
+Express the amplitudes trigonometrically for later convenience:
+
+$$
+|s\rangle = \frac{1}{\sqrt{N}}|\omega\rangle + \frac{\sqrt{N-1}}{\sqrt{N}}|\omega_\perp\rangle = \sin(\theta)|\omega\rangle + \cos(\theta)|\omega_\perp\rangle.
+$$
+
+The Grover operator \(G\) is two consecutive Householder reflections: the oracle \(U_\omega\) and the diffusion (inversion-about-the-mean) operator \(U_s\):
+
+$$
+U_{\omega}=I-2|\omega\rangle\langle\omega|,\qquad
+U_{s}= -(I - 2|s\rangle\langle s|),\qquad
+G = U_s\,U_\omega.
+$$
+
+Each application of \(G\) amplifies the amplitude of \(|\omega\rangle\) up to an optimal number of iterations derived below.
+
+![Amplitude amplification for a single marked item in a 64-element space](/images/grovers-algorithm-guide/amplitude-amplification.svg)
+
+### Matrix representation of Grover operator
+
+Using Sympy in the basis \(\{|\omega\rangle, |\omega_\perp\rangle\}\):
+
+```python
+from sympy import Matrix, symbols, sin, cos, eye
+
+θ = symbols('theta', real=True, positive=True)
+ω = Matrix([1, 0])
+s = Matrix([sin(θ), cos(θ)])
+
+Uω = eye(2) - 2*(ω * ω.T)
+Us = 2*(s * s.T) - eye(2)
+```
+
+The diffusion operator simplifies to
+
+$$
+U_s = \begin{bmatrix}
+-\cos(2\theta) & \sin(2\theta)\\
+\sin(2\theta) & \cos(2\theta)
+\end{bmatrix},
+$$
+
+and the Grover operator
+
+$$
+G = \begin{bmatrix}
+\cos(2\theta) & \sin(2\theta)\\
+-\sin(2\theta) & \cos(2\theta)
+\end{bmatrix}.
+$$
+
+### Amplitude of our target state after one iteration of the Grover operator
+
+The amplitude of \(|\omega\rangle\) after one Grover iteration starting from \(|s\rangle\) is
+
+$$
+\langle \omega | G | s \rangle = \sin(3\theta),
+$$
+
+which is larger than the starting amplitude for sufficiently large \(N\) (small \(\theta\)).
+
+### Diagonalization of the Grover operator
+
+Diagonalizing \(G\) makes repeated applications simple. Its eigenvalues in the reordered basis are
+
+$$
+\Lambda = \operatorname{diag}(e^{2 i \theta},\, e^{-2 i \theta}),
+$$
+
+with change-of-basis matrix
+
+$$
+C_m = \begin{bmatrix}
+-i & i\\
+1 & 1
+\end{bmatrix}.
+$$
+
+Raising \(G\) to the \(r\)th power amounts to powering the diagonal matrix:
+
+$$
+G^r = C_m\,\Lambda^r\,C_m^{-1} = C_m \begin{bmatrix}
+e^{2 i r \theta} & 0\\
+0 & e^{-2 i r \theta}
+\end{bmatrix} C_m^{-1}.
+$$
+
+![Rotation of the state vector toward the marked subspace across Grover iterations](/images/grovers-algorithm-guide/state-rotation.svg)
+
+### Complexity of the algorithm and optimal number of iterations
+
+Starting from \(|s\rangle\), after \(r\) Grover iterations the success probability is
+
+$$
+p = |\langle \omega | G^r | s \rangle|^2 = \sin^2\bigl(\theta(2r + 1)\bigr).
+$$
+
+The optimum occurs when \(\theta(2r + 1) \approx \pi/2\), giving
+
+$$
+r \approx \frac{\pi}{4}\sqrt{N} + O(1; N \to \infty),
+$$
+
+so the algorithm scales as \(O(\sqrt{N})\). Overshooting the optimum causes the probability to decrease as the rotation continues.
+
+## Notes on the oracle
+
+Many didactic treatments use an oracle that assumes the answer. Practical oracles can be built as quantum lookup tables \(T(i)=x\), but constructing them efficiently is challenging. Recent proposals achieve \(O(\sqrt{N})\) scaling for lookup; see [qLUT][qLUT] and [QRAM][QRAM].
+
+## Sources
+
+- https://arxiv.org/pdf/quant-ph/9605043 — original paper  
+- https://arxiv.org/pdf/quant-ph/9605034 — proves it cannot be done faster than \(O(\sqrt{N})\)  
+- https://arxiv.org/pdf/quant-ph/9711070 — proves it cannot be parallelised faster  
+- https://github.com/Qiskit/textbook/blob/main/notebooks/ch-algorithms/grover.ipynb — comprehensive notebook using Qiskit  
+- https://en.wikipedia.org/wiki/Amplitude_amplification — reference for amplitude amplification  
+- https://en.wikipedia.org/wiki/Grover%27s_algorithm — background material  
+- https://www.cs.cmu.edu/~odonnell/quantum15/lecture04.pdf — detailed lecture notes  
+- https://arxiv.org/pdf/1812.00954 — first \(O(\sqrt{N})\) oracle  
+- https://arxiv.org/abs/2408.16794 — state-of-the-art oracle
+
+[binary-search]: https://en.wikipedia.org/wiki/Binary_search
+[qa-paper]: https://arxiv.org/pdf/2307.00523
+[amp]: https://en.wikipedia.org/wiki/Amplitude_amplification
+[oracle]: https://arxiv.org/abs/2408.16794
+[qLUT]: https://arxiv.org/pdf/1812.00954
+[QRAM]: https://arxiv.org/abs/2408.16794

--- a/static/images/grovers-algorithm-guide/amplitude-amplification.svg
+++ b/static/images/grovers-algorithm-guide/amplitude-amplification.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="300" viewBox="0 0 500 300">
+  <style>
+    text { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 12px; }
+  </style>
+  <rect x="0" y="0" width="500" height="300" fill="#fff" stroke="#e5e7eb" />
+  <polyline points="40,20 40,260 480,260" fill="none" stroke="#374151" stroke-width="1.2" />
+  <polyline points="40.0,256.6 70.0,230.3 100.0,184.3 130.0,129.9 160.0,80.4 190.0,48.0 220.0,40.8 250.0,60.4 280.0,102.0 310.0,155.5 340.0,207.6 370.0,245.6 400.0,260.0 430.0,247.3 460.0,210.7" fill="none" stroke="#0b6e4f" stroke-width="2" />
+  <g fill="#0b6e4f">
+    <circle cx="40.0" cy="256.6" r="3" /><circle cx="70.0" cy="230.3" r="3" /><circle cx="100.0" cy="184.3" r="3" /><circle cx="130.0" cy="129.9" r="3" /><circle cx="160.0" cy="80.4" r="3" /><circle cx="190.0" cy="48.0" r="3" /><circle cx="220.0" cy="40.8" r="3" /><circle cx="250.0" cy="60.4" r="3" /><circle cx="280.0" cy="102.0" r="3" /><circle cx="310.0" cy="155.5" r="3" /><circle cx="340.0" cy="207.6" r="3" /><circle cx="370.0" cy="245.6" r="3" /><circle cx="400.0" cy="260.0" r="3" /><circle cx="430.0" cy="247.3" r="3" /><circle cx="460.0" cy="210.7" r="3" />
+  </g>
+  <line x1="220" y1="40" x2="220" y2="260" stroke="#c54f1f" stroke-dasharray="6 4" stroke-width="1.5" />
+  <text x="250" y="18" text-anchor="middle" font-size="14" font-weight="600">Grover amplitude amplification for N=64, M=1</text>
+  <text x="250" y="290" text-anchor="middle">Iterations k</text>
+  <text x="12" y="40" text-anchor="start" transform="rotate(-90 12 40)">Success probability</text>
+  <text x="226" y="54" fill="#c54f1f">Approx. optimum</text>
+</svg>

--- a/static/images/grovers-algorithm-guide/state-rotation.svg
+++ b/static/images/grovers-algorithm-guide/state-rotation.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="350" viewBox="0 0 500 350">
+<style> text { font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 12px; } </style>
+<rect x="0" y="0" width="500" height="350" fill="#fff" stroke="#e5e7eb" />
+<line x1="80" y1="250" x2="420" y2="250" stroke="#9ca3af" stroke-width="1" stroke-dasharray="4 4" />
+<line x1="250" y1="330" x2="250" y2="70" stroke="#9ca3af" stroke-width="1" stroke-dasharray="4 4" />
+<line x1="250" y1="250" x2="250" y2="80" stroke="#c54f1f" stroke-width="2" marker-end="url(#arrow-red)" />
+<line x1="250" y1="250" x2="420" y2="250" stroke="#0b6e4f" stroke-width="2" marker-end="url(#arrow-green)" />
+<defs>
+  <marker id="arrow-blue" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="#1f77b4"/>
+  </marker>
+  <marker id="arrow-red" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="#c54f1f"/>
+  </marker>
+  <marker id="arrow-green" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+    <path d="M 0 0 L 10 5 L 0 10 z" fill="#0b6e4f"/>
+  </marker>
+</defs>
+<text x="260" y="85" fill="#c54f1f">|w> (marked state)</text>
+<text x="365" y="240" fill="#0b6e4f">|r> (rest)</text>
+<line x1="250" y1="250" x2="383.1" y2="206.7" stroke="#1f77b4" stroke-width="2.2" marker-end="url(#arrow-blue)" opacity="0.78" />
+<text x="383.1" y="196.7" text-anchor="middle" fill="#1f77b4">k=0</text>
+<line x1="250" y1="250" x2="332.3" y2="136.7" stroke="#1f77b4" stroke-width="2.2" marker-end="url(#arrow-blue)" opacity="0.78" />
+<text x="332.3" y="126.7" text-anchor="middle" fill="#1f77b4">k=1</text>
+<line x1="250" y1="250" x2="250.0" y2="110.0" stroke="#1f77b4" stroke-width="2.2" marker-end="url(#arrow-blue)" opacity="0.78" />
+<text x="250.0" y="100.0" text-anchor="middle" fill="#1f77b4">k=2</text>
+<line x1="250" y1="250" x2="167.7" y2="136.7" stroke="#1f77b4" stroke-width="2.2" marker-end="url(#arrow-blue)" opacity="0.78" />
+<text x="167.7" y="126.7" text-anchor="middle" fill="#1f77b4">k=3</text>
+<line x1="250" y1="250" x2="116.9" y2="206.7" stroke="#1f77b4" stroke-width="2.2" marker-end="url(#arrow-blue)" opacity="0.78" />
+<text x="116.9" y="196.7" text-anchor="middle" fill="#1f77b4">k=4</text>
+<text x="250" y="36" text-anchor="middle" font-size="14" font-weight="600">Rotation of the state vector across Grover iterations</text>
+<text x="250" y="340" text-anchor="middle">Angles grow by 2θ per iteration in the |w>, |r> plane</text>
+</svg>


### PR DESCRIPTION
### Motivation

- Align the site content with the original notebook exposition so the guide preserves the same derivations and flow for readers.  
- Include the Sympy-based matrix derivation and probability expressions to keep the mathematical steps reproducible.  
- Provide site-relative images so diagrams are served by the website and referenced consistently from the content.  

### Description

- Replace `content/grovers-algorithm-guide/_index.md` with a rewritten guide that follows the notebook structure (Introduction, Algorithm Outline, matrix derivation, diagonalization, amplitude analysis, oracle notes, and sources).  
- Add two SVG diagrams at `static/images/grovers-algorithm-guide/amplitude-amplification.svg` and `static/images/grovers-algorithm-guide/state-rotation.svg` and reference them from the page using site-relative paths.  
- Reintroduce the Sympy snippets and symbolic derivation (e.g., `Matrix`, `symbols`, `sin`, `cos`) and the key expressions such as `
`p = sin^2(theta*(2*r + 1))`
` and the optimal iteration estimate `r ≈ π/4 * sqrt(N)`.  
- Preserve and update front-matter (`title`, `slug`, `draft`, `layout`, `description`) and links/references (`[oracle]`, `[qLUT]`, `[QRAM]`).

### Testing

- No automated unit tests were run as part of this change.  
- No site build (`hugo`) or CI jobs were executed for validation.  
- No automated linting or spellcheck was executed.  
- Manual inspection was used to verify content structure and image references.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3dc0d0dc8320996dc814e230b3f8)