### PR TITLE
Add Grover's Algorithm Guide to main menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,10 @@ copyright = '© {year} Flax & Teal Limited.'
     pageRef = '/clients'
     weight = 40
   [[menus.main]]
+    name = "Grover's Algorithm Guide"
+    pageRef = '/grovers-algorithm-guide'
+    weight = 42
+  [[menus.main]]
     name = 'Contact Us'
     pageRef = '/contact'
     weight = 50


### PR DESCRIPTION
### Motivation
- Add a new top-level navigation item for the Grover's Algorithm Guide so it appears between Clients (weight 40) and Contact Us (weight 50). 
- Ensure the link is available in both desktop and mobile menus by relying on the shared main menu data consumed by the navigation partial `layouts/partials/nav-new.html`.

### Description
- Inserted a new `[[menus.main]]` entry in `config.toml` with `name = "Grover's Algorithm Guide"`, `pageRef = '/grovers-algorithm-guide'`, and `weight = 42`.
- No changes to `layouts/partials/nav-new.html` were required because it already iterates `site.Menus.main` for both desktop and mobile menus.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4676bfa883208cf5aebb54ae08fd)