### PR TITLE
Add conditional MathJax support and enable math for Grover guide

### DIFF
--- a/assets/sass/_new.scss
+++ b/assets/sass/_new.scss
@@ -20,6 +20,16 @@ body{
   font-size: 16px;
 }
 
+.math-display {
+  overflow-x: auto;
+  padding: 0.25rem 0.5rem;
+  margin: 1rem 0;
+}
+
+.math-inline {
+  white-space: nowrap;
+}
+
 .container{
   max-width: 1440px;
 }

--- a/content/grovers-algorithm-guide/_index.md
+++ b/content/grovers-algorithm-guide/_index.md
@@ -4,6 +4,7 @@ slug: "grovers-algorithm-guide"
 draft: false
 layout: "single"
 description: "A step-by-step walkthrough of Grover's quantum search algorithm, including the oracle, diffusion operator, and amplitude amplification schedule."
+math: true
 ---
 
 ## Introduction

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,5 +7,8 @@
     <link rel='stylesheet' href='/fonts/league-spartan/stylesheet.css' type='text/css' />
     {{ $style := resources.Get "sass/style.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $style.Permalink }}">
+    {{ if .Param "math" }}
+      {{ partial "math.html" . }}
+    {{ end }}
   </head>
   

--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -1,0 +1,11 @@
+{{/* Loads MathJax from CDN when `math: true` is set in page front matter */}}
+<script>
+  window.MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']]
+    },
+    options: { skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'] }
+  };
+</script>
+<script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
### Motivation
- Load math rendering only on pages that opt in to avoid adding MathJax site-wide and extra asset weight.
- Enable the Grover's Algorithm guide to render LaTeX math in-place using inline (`$...$`, `\(...\)`) and display (`$$...$$`, `\[...\]`) delimiters.
- Provide minimal styling hooks for inline and block math to ensure readable formatting and overflow handling.
- Keep the existing Hugo CSS pipeline (fingerprinting) in place so the stylesheet changes are included in the normal build.

### Description
- Added a conditional include in `layouts/partials/header.html` that calls `{{ partial "math.html" . }}` when a page sets `math: true` in front matter.
- Added `layouts/partials/math.html` which configures `window.MathJax` and loads MathJax v3 from the CDN to support the chosen delimiters.
- Marked the Grover guide with `math: true` by updating `content/grovers-algorithm-guide/_index.md` so the guide will load MathJax.
- Added simple math-specific styles to `assets/sass/_new.scss` (`.math-display` and `.math-inline`) to handle overflow and whitespace for rendered formulas.

### Testing
- No automated tests were run for this change.
- Verified repository status with `git status` and reviewed diffs with `git diff` before committing the changes.
- Commit was created with message `Add conditional math support for Grover guide` (local commit succeeded).
- Manual site build or browser verification was not executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d49036cf4832080722ff18189c5dc)