### PR TITLE
Add Scientific Software & Simulation (Photonics) capability page, service block, and nav entry

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,10 @@ copyright = '© {year} Flax & Teal Limited.'
     pageRef = '/services'
     weight = 20
   [[menus.main]]
+    name = 'Scientific Software & Simulation'
+    pageRef = '/services/scientific-software-simulation-photonics'
+    weight = 25
+  [[menus.main]]
     name = 'Products'
     pageRef = '/products'
     weight = 30

--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -39,6 +39,14 @@ sections:
     cta_link: '/clients/'
     order: 1
   - type: value-details
+    bg_color: '#334B4E'
+    tags: ['Photonics', 'Simulation', 'Engineering']
+    title: 'Scientific Software <br> & Simulation (Photonics)'
+    img: '/images/services/software-development-research-image.webp'
+    cta: 'Learn more → Scientific Software & Simulation for Photonics'
+    cta_link: '/services/scientific-software-simulation-photonics/'
+    order: 2
+  - type: value-details
     bg_color: '#F1F7F5'
     text_color: text-dark
     btn_color: btn-dark
@@ -48,14 +56,14 @@ sections:
     cta: 'Discover projects'
     cta_link: '/clients/'
     reverse: true
-    order: 2
+    order: 3
   - type: value-details
     bg_color: '#334B4E'
     title: 'Approved <br> Suppliers'
     img: '/images/services/approved-supplier.webp'
     cta: 'Discover projects'
     cta_link: '/clients/'
-    order: 3
+    order: 4
   - type: contact-ctx
     heading: 'Let’s work together'
     text: 'Interested in our work? We’d love to hear more about your particular needs – and we’re confident we can guide you. <br><br> For enquiries email info@flaxandteal.co.uk'
@@ -86,6 +94,23 @@ Health, enterprise, simulation, engineering, journalism, <br> public sector, edu
 **Global Clients**
 
 UK, Germany, New Zealand and US
+
+---
+
+**Scientific Software & Simulation (Photonics)**
+
+We support photonics, semiconductor, and advanced engineering teams to design, scale, and modernise scientific software and simulation workflows — from early-stage R&D through to production-grade platforms.
+
+Our work sits at the intersection of physics-based modelling, high-performance computing, and cloud-native software engineering, with a strong emphasis on reproducibility, validation, and long-term maintainability. We use open source strategically where appropriate, while protecting intellectual property and preserving scientific integrity.
+
+Typical engagements include:
+- Optical and semiconductor simulation pipelines and legacy solvers
+- Cloud and HPC enablement for compute-intensive modelling
+- Automation and reproducibility of scientific workflows
+- Responsible ML and AI used to augment physics-based models
+- Productising internal R&D tools into shared engineering platforms
+
+[Learn more → Scientific Software & Simulation for Photonics](/services/scientific-software-simulation-photonics/)
 
 ---
 

--- a/content/services/scientific-software-simulation-photonics
+++ b/content/services/scientific-software-simulation-photonics
@@ -1,0 +1,99 @@
+---
+title: "Scientific Software & Simulation for Photonics"
+description: "Scientific software and simulation support for photonics and semiconductor engineering, spanning physics-based modelling, HPC workflows, and cloud-native platforms."
+date: 2025-01-18T00:00:00Z
+draft: false
+aliases: ['/simulation']
+---
+
+# Scientific Software & Simulation for Photonics
+
+## Scientific software and simulation for photonics and semiconductor engineering
+
+*Supporting R\&D‑driven organisations to scale simulation, modernise scientific software, and productise complex models – without losing trust in the physics.*
+
+## Who we are
+
+Flax & Teal is a specialist software and scientific computing consultancy working at the intersection of **physics, simulation, data science, and cloud infrastructure,** with a strong emphasis on open, transparent, and sustainable software practices.
+
+We collaborate with photonics, semiconductor, sensing, and advanced engineering teams to modernise complex scientific software and workflows, using open source where appropriate, while protecting intellectual property and preserving scientific integrity.
+
+We regularly work with industry, research, and cluster partners across the UK, Ireland, EU, North America, and Asia.
+
+## Where we typically help
+
+We are often brought in when simulation or modelling capability becomes a constraint rather than a differentiator:
+
+* Scientific and optical simulation that no longer scales beyond individual machines  
+* Legacy solver code (Python, C++, Fortran, mixed stacks) that is difficult to extend or maintain  
+* On‑prem or desktop tools that need secure cloud or HPC enablement  
+* Increasing demand for parallelisation, automation, and reproducibility  
+* Cautious exploration of ML or AI alongside physics‑based models  
+* Internal R\&D tooling that needs to evolve into a reliable engineering or product platform
+
+## Core capabilities
+
+### Scientific computing & simulation
+
+* Optical, semiconductor, and physics‑based simulation pipelines  
+* FEM, PDE‑driven models, numerical methods  
+* Parallelisation using Python, Dask, Kubernetes, and HPC environments
+
+### Cloud & infrastructure for science
+
+* Cloud‑native orchestration for simulation workloads  
+* Secure, reproducible CI/CD for scientific software  
+* Cost‑aware scaling for bursty and high‑volume compute
+
+### Data, ML & AI (applied responsibly)
+
+* Machine learning used to augment, not replace, physical models  
+* Validation‑led proof‑of‑concepts  
+* Integration into existing scientific and engineering workflows
+
+### Product & platform enablement
+
+* Turning internal tools into usable, maintainable platforms  
+* APIs, dashboards, and visualisation for non‑expert users  
+* Knowledge transfer and long‑term sustainability built in
+
+## Selected experience
+
+**Semiconductor optics simulation**   
+Refactoring licensed, legacy simulation code into modular, cloud‑ready workflows; enabling high‑volume, bursty simulation across teams; estimated upwards of €60m savings through modularisation and optimisation.
+
+**Sensor and telemetry systems**   
+Near‑real‑time ingestion and analysis of large‑scale sensor data; secure, multi‑tenant cloud infrastructure; ML‑driven insights integrated into operational systems.
+
+**Scientific R\&D collaboration**   
+FEM‑based electromagnetic modelling; HPC‑enabled 3D simulation; reproducible, open scientific pipelines developed alongside domain experts.
+
+*Additional photonics and semiconductor case studies available.*
+
+## How we engage
+
+We typically work in focused, low‑risk stages designed to build confidence early:
+
+* Discovery and feasibility assessments  
+* Proof‑of‑concept simulation or refactoring work  
+* Architecture and technical roadmap definition  
+* Embedded collaboration alongside internal teams  
+* Ongoing support for critical scientific tooling
+
+Our approach is collaborative, transparent, and grounded in practical delivery.
+
+## How we work
+
+* Clear IP boundaries; client‑owned code remains client‑owned  
+* Open source used strategically, not ideologically  
+* No vendor lock‑in  
+* Knowledge transfer and enablement built into delivery
+
+## Get in touch
+
+If your organisation is exploring how to scale simulation, modernise scientific software, or responsibly integrate AI into physics‑led environments, we would welcome a conversation.
+
+📧 [info@flaxandteal.co.uk](mailto:info@flaxandteal.co.uk) 🌐 flaxandteal.co.uk
+
+Flax & Teal Limited   
+Belfast, UK | Global delivery


### PR DESCRIPTION
### Motivation

- Introduce a dedicated capability page for photonics simulation to present the new offering and provide a short-url alias (`/simulation`).
- Surface the capability on the Services overview and primary navigation so visitors can discover and navigate to the new page.

### Description

- Add `content/services/scientific-software-simulation-photonics` with SEO front matter and `aliases: ['/simulation']` containing the provided markdown body.
- Insert a new `value-details` service block into `content/services/_index.md` linking to the new capability and update the ordering of subsequent blocks.
- Add a main menu entry in `config.toml` pointing to `/services/scientific-software-simulation-photonics`.

### Testing

- Attempted to run `hugo version` to validate a local build but it failed (`hugo` not installed), so the site build was not executed and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d0b0d5690832093f1bee505697fee)