### PR TITLE
Add dropdown rendering for menu children in navigation

### DIFF
--- a/layouts/partials/nav-new.html
+++ b/layouts/partials/nav-new.html
@@ -8,9 +8,18 @@
   <div class="right">
     <ul class="flex gap-2">
       {{ range site.Menus.main}}
-        {{ if in .URL "contact"}} 
+        {{ if .HasChildren }}
+          <li class="nav-dropdown">
+            <a class="text-dark" href="{{.URL}}">{{.Name}}</a>
+            <ul class="nav-dropdown-menu">
+              {{ range .Children }}
+                <li><a class="text-dark" href="{{.URL}}">{{.Name}}</a></li>
+              {{ end }}
+            </ul>
+          </li>
+        {{ else if in .URL "contact"}} 
           <li><a class="btn btn-primary text-light" href="{{.URL}}">{{.Name}}</a></li>
-          {{ else }}
+        {{ else }}
           <li><a class="text-dark" href="{{.URL}}">{{.Name}}</a></li>
         {{ end }}
       {{ end }}      
@@ -24,7 +33,16 @@
     </button>
     <ul>
       {{ range site.Menus.main}}
-      {{ if in .URL "contact"}} 
+      {{ if .HasChildren }}
+      <li class="nav-dropdown">
+        <a class="text-dark" href="{{.URL}}">{{.Name}}</a>
+        <ul class="nav-dropdown-menu">
+          {{ range .Children }}
+          <li><a class="text-dark" href="{{.URL}}">{{.Name}}</a></li>
+          {{ end }}
+        </ul>
+      </li>
+      {{ else if in .URL "contact"}} 
       <li><a class="btn btn-primary text-light" href="{{.URL}}">{{.Name}}</a></li>
       {{ else }}
       <li><a class="text-dark" href="{{.URL}}">{{.Name}}</a></li>


### PR DESCRIPTION
### Motivation
- Provide nested menu support so items with children (e.g., “Business Support”) expose their child pages (such as “AI for Business Support” and “DTFF Support”) as a dropdown in the desktop nav.
- Ensure the same accessible structure exists in the mobile menu and retain the existing “Contact Us” button styling for standalone items.

### Description
- Update `layouts/partials/nav-new.html` to detect `.HasChildren` and render a nested `<ul class="nav-dropdown-menu">` with links generated from `.Children`.
- Add `nav-dropdown` and `nav-dropdown-menu` wrappers in the desktop `<ul class="flex gap-2">` and mirror the same nesting in the mobile menu `<ul>`.
- Preserve existing `Contact Us` styling by keeping the `in .URL "contact"` branch for rendering the button.
- No other templates or assets were modified.

### Testing
- Attempted to run `hugo version` to validate the site build, which failed because `hugo` is not installed in the environment.
- No automated site builds or tests were executed as a result.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d15110608832097bf820e717dd85a)