### PR TITLE
Group business support menu items under dropdown

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,11 @@ copyright = '© {year} Flax & Teal Limited.'
     pageRef = '/clients'
     weight = 40
   [[menus.main]]
+    name = 'Business Support'
+    identifier = 'business-support'
+    pageRef = '/services'
+    weight = 45
+  [[menus.main]]
     name = "Grover's Algorithm Guide"
     pageRef = '/grovers-algorithm-guide'
     weight = 42

--- a/content/ai-readiness/_index.md
+++ b/content/ai-readiness/_index.md
@@ -7,7 +7,7 @@ menu:
   main:
     name: "AI Readiness Quiz"
     weight: 46
-    parent: "AI for Business Workshops"
+    parent: "ai-business-support"
 ---
 
 Understand where your organisation stands on the AI readiness journey. This quick diagnostic takes 5 minutes and provides personalised insights based on your responses.

--- a/content/aiforbusiness/_index.md
+++ b/content/aiforbusiness/_index.md
@@ -5,8 +5,10 @@ aliases: ["/aiforbusiness/"]
 draft: false
 menu:
   main:
-    name: "AI for Business Workshops"
-    weight: 45
+    name: "AI for Business Support"
+    identifier: "ai-business-support"
+    parent: "business-support"
+    weight: 10
 layout: services
 
 sections:

--- a/content/dtff/_index.md
+++ b/content/dtff/_index.md
@@ -8,7 +8,8 @@ draft: false
 menu:
   main:
     name: "DTFF Support"
-    weight: 45
+    parent: "business-support"
+    weight: 20
 
 layout: services
 

--- a/layouts/partials/nav-new.html
+++ b/layouts/partials/nav-new.html
@@ -8,9 +8,18 @@
   <div class="right">
     <ul class="flex gap-2">
       {{ range site.Menus.main}}
-        {{ if in .URL "contact"}} 
+        {{ if .Children }}
+          <li class="nav-dropdown">
+            <a class="text-dark" href="{{.URL}}">{{.Name}}</a>
+            <ul class="nav-dropdown-menu">
+              {{ range .Children }}
+                <li><a class="text-dark" href="{{.URL}}">{{.Name}}</a></li>
+              {{ end }}
+            </ul>
+          </li>
+        {{ else if in .URL "contact"}} 
           <li><a class="btn btn-primary text-light" href="{{.URL}}">{{.Name}}</a></li>
-          {{ else }}
+        {{ else }}
           <li><a class="text-dark" href="{{.URL}}">{{.Name}}</a></li>
         {{ end }}
       {{ end }}      
@@ -24,7 +33,16 @@
     </button>
     <ul>
       {{ range site.Menus.main}}
-      {{ if in .URL "contact"}} 
+      {{ if .Children }}
+      <li class="nav-dropdown">
+        <a class="text-dark" href="{{.URL}}">{{.Name}}</a>
+        <ul class="nav-dropdown-menu">
+          {{ range .Children }}
+          <li><a class="text-dark" href="{{.URL}}">{{.Name}}</a></li>
+          {{ end }}
+        </ul>
+      </li>
+      {{ else if in .URL "contact"}} 
       <li><a class="btn btn-primary text-light" href="{{.URL}}">{{.Name}}</a></li>
       {{ else }}
       <li><a class="text-dark" href="{{.URL}}">{{.Name}}</a></li>


### PR DESCRIPTION
### Motivation
- Expose related pages under a single parent in the nav so `AI for Business`, `DTFF Support`, and the `AI Readiness` quiz appear as a dropdown under a new “Business Support” parent in both desktop and mobile navigation.
- Render accessible nested menus in the template while preserving the existing special-case styling for the `Contact Us` button.

### Description
- Updated `layouts/partials/nav-new.html` to check for menu `.Children` and render a `<li class="nav-dropdown">` with a nested `<ul class="nav-dropdown-menu">` for both the desktop (`.right > ul`) and mobile (`.menu-mobile > ul`) menus and retained the `in .URL "contact"` branch for the CTA button.
- Added a `Business Support` entry to `config.toml` with `identifier = 'business-support'` so it can act as a parent menu item.
- Modified `content/aiforbusiness/_index.md` to rename the menu label to `AI for Business Support`, add `identifier = "ai-business-support"`, and set `parent = "business-support"` so it becomes a child.
- Updated `content/dtff/_index.md` and `content/ai-readiness/_index.md` to set their `parent` fields to `business-support`/`ai-business-support` and adjusted weights so they appear under the new parent.

### Testing
- No automated site build or tests were run because `hugo` is not available in the environment, so the site build could not be validated.
- The repository’s CI workflow previously reported a failure, and no new CI/deploy run was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d15110608832097bf820e717dd85a)