### PR TITLE
Disable photonics service content

### DIFF
--- a/content/services/scientific-software-simulation-photonics
+++ b/content/services/scientific-software-simulation-photonics
@@ -2,7 +2,10 @@
 title: "Scientific Software & Simulation for Photonics"
 description: "Scientific software and simulation support for photonics and semiconductor engineering, spanning physics-based modelling, HPC workflows, and cloud-native platforms."
 date: 2025-01-18T00:00:00Z
-draft: false
+draft: true
+build:
+  render: never
+  list: never
 aliases: ['/simulation']
 ---
 

--- a/content/services/scientific-software-simulation-photonics.md
+++ b/content/services/scientific-software-simulation-photonics.md
@@ -2,7 +2,10 @@
 title: "Scientific Software & Simulation for Photonics"
 description: "Scientific software and simulation support for photonics and semiconductor engineering, spanning physics-based modelling, HPC workflows, and cloud-native platforms."
 date: 2025-01-18T00:00:00Z
-draft: false
+draft: true
+build:
+  render: never
+  list: never
 aliases: ['/simulation']
 ---
 


### PR DESCRIPTION
### Motivation
- Prevent the `/services/scientific-software-simulation-photonics/` page from being published by disabling the source content and instructing Hugo not to render or list it.

### Description
- Updated front matter in `content/services/scientific-software-simulation-photonics` and `content/services/scientific-software-simulation-photonics.md` to set `draft: true` and add `build: { render: never, list: never }`.

### Testing
- No automated tests were run because this is a content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d8c9bad3c8320b4997c8ab2ed99d0)