### PR TITLE
Remove Scientific Software & Simulation menu entry

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,10 +16,6 @@ copyright = '© {year} Flax & Teal Limited.'
     pageRef = '/services'
     weight = 20
   [[menus.main]]
-    name = 'Scientific Software & Simulation'
-    pageRef = '/services/scientific-software-simulation-photonics'
-    weight = 25
-  [[menus.main]]
     name = 'Products'
     pageRef = '/products'
     weight = 30


### PR DESCRIPTION
### Motivation
- Remove the navigation item that pointed to `/services/scientific-software-simulation-photonics` so it no longer appears in the site header.

### Description
- Deleted the `[[menus.main]]` block for `Scientific Software & Simulation` from `config.toml`; the header partials render `site.Menus.main` so removing the entry removes the label from the navigation.

### Testing
- Could not run an automated Hugo build because `hugo` is not installed in the environment; `hugo version` returned `command not found`, so no site build/tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d8ca092f08320a8dd56a1978192fc)