### PR TITLE
Remove photonics services section

### DIFF
--- a/content/services/_index.md
+++ b/content/services/_index.md
@@ -39,14 +39,6 @@ sections:
     cta_link: '/clients/'
     order: 1
   - type: value-details
-    bg_color: '#334B4E'
-    tags: ['Photonics', 'Simulation', 'Engineering']
-    title: 'Scientific Software <br> & Simulation (Photonics)'
-    img: '/images/services/software-development-research-image.webp'
-    cta: 'Learn more → Scientific Software & Simulation for Photonics'
-    cta_link: '/services/scientific-software-simulation-photonics/'
-    order: 2
-  - type: value-details
     bg_color: '#F1F7F5'
     text_color: text-dark
     btn_color: btn-dark
@@ -56,14 +48,14 @@ sections:
     cta: 'Discover projects'
     cta_link: '/clients/'
     reverse: true
-    order: 3
+    order: 2
   - type: value-details
     bg_color: '#334B4E'
     title: 'Approved <br> Suppliers'
     img: '/images/services/approved-supplier.webp'
     cta: 'Discover projects'
     cta_link: '/clients/'
-    order: 4
+    order: 3
   - type: contact-ctx
     heading: 'Let’s work together'
     text: 'Interested in our work? We’d love to hear more about your particular needs – and we’re confident we can guide you. <br><br> For enquiries email info@flaxandteal.co.uk'
@@ -94,23 +86,6 @@ Health, enterprise, simulation, engineering, journalism, <br> public sector, edu
 **Global Clients**
 
 UK, Germany, New Zealand and US
-
----
-
-**Scientific Software & Simulation (Photonics)**
-
-We support photonics, semiconductor, and advanced engineering teams to design, scale, and modernise scientific software and simulation workflows — from early-stage R&D through to production-grade platforms.
-
-Our work sits at the intersection of physics-based modelling, high-performance computing, and cloud-native software engineering, with a strong emphasis on reproducibility, validation, and long-term maintainability. We use open source strategically where appropriate, while protecting intellectual property and preserving scientific integrity.
-
-Typical engagements include:
-- Optical and semiconductor simulation pipelines and legacy solvers
-- Cloud and HPC enablement for compute-intensive modelling
-- Automation and reproducibility of scientific workflows
-- Responsible ML and AI used to augment physics-based models
-- Productising internal R&D tools into shared engineering platforms
-
-[Learn more → Scientific Software & Simulation for Photonics](/services/scientific-software-simulation-photonics/)
 
 ---
 


### PR DESCRIPTION
### Motivation
- Remove the Photonics-specific service offering and its rendered description from the Services page to stop it appearing in the site content and links. 
- Keep the services list ordering consistent after removing the Photonics entry.

### Description
- Deleted the `value-details` frontmatter entry tagged `['Photonics', 'Simulation', 'Engineering']` in `content/services/_index.md` so the Photonics card is no longer defined. 
- Removed the corresponding markdown body section titled **Scientific Software & Simulation (Photonics)** including the `Learn more → Scientific Software & Simulation for Photonics` link. 
- Updated the `order` values on the remaining `value-details` blocks to maintain a contiguous sequence.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5df5b86c8320b5aad0e77c60b069)