### PR TITLE
Update menu structure for business pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,11 +24,6 @@ copyright = '© {year} Flax & Teal Limited.'
     pageRef = '/clients'
     weight = 40
   [[menus.main]]
-    name = 'Business Support'
-    identifier = 'business-support'
-    pageRef = '/services'
-    weight = 45
-  [[menus.main]]
     name = "Grover's Algorithm Guide"
     pageRef = '/grovers-algorithm-guide'
     weight = 42

--- a/content/ai-readiness/_index.md
+++ b/content/ai-readiness/_index.md
@@ -7,7 +7,7 @@ menu:
   main:
     name: "AI Readiness Quiz"
     weight: 46
-    parent: "ai-business-support"
+    parent: "AI for Business Workshops"
 ---
 
 Understand where your organisation stands on the AI readiness journey. This quick diagnostic takes 5 minutes and provides personalised insights based on your responses.

--- a/content/aiforbusiness/_index.md
+++ b/content/aiforbusiness/_index.md
@@ -5,9 +5,7 @@ aliases: ["/aiforbusiness/"]
 draft: false
 menu:
   main:
-    name: "AI for Business Support"
-    identifier: "ai-business-support"
-    parent: "business-support"
+    name: "AI for Business Workshops"
     weight: 10
 layout: services
 

--- a/content/dtff/_index.md
+++ b/content/dtff/_index.md
@@ -8,7 +8,6 @@ draft: false
 menu:
   main:
     name: "DTFF Support"
-    parent: "business-support"
     weight: 20
 
 layout: services


### PR DESCRIPTION
### Motivation
- Reorganise site navigation to remove the intermediate `Business Support` parent so workshop and support pages appear as top-level menu items.
- Ensure `AI Readiness Quiz` remains grouped beneath the `AI for Business Workshops` heading.
- Simplify menu rendering so nested dropdowns are not required by default.

### Description
- Removed the `Business Support` `[[menus.main]]` block from `config.toml`.
- Restored `content/aiforbusiness/_index.md` as a top-level menu item by removing `parent` and `identifier` and setting `name` to "AI for Business Workshops".
- Removed the `parent` field from `content/dtff/_index.md` so `DTFF Support` is top-level.
- Updated `content/ai-readiness/_index.md` to set `parent: "AI for Business Workshops"` so the quiz is a child of the workshops.
- Left `layouts/partials/nav-new.html` unchanged; dropdown markup remains but will be inactive when no items have children.

### Testing
- No automated tests were run for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6077eefc83209e60693c9b1ea7db)