### PR TITLE
Reorder main menu: place AI for Business and DTFF after Grover’s Algorithm Guide

### DIFF
--- a/content/aiforbusiness/_index.md
+++ b/content/aiforbusiness/_index.md
@@ -6,7 +6,7 @@ draft: false
 menu:
   main:
     name: "AI for Business Workshops"
-    weight: 10
+    weight: 44
 layout: services
 
 sections:

--- a/content/dtff/_index.md
+++ b/content/dtff/_index.md
@@ -8,7 +8,7 @@ draft: false
 menu:
   main:
     name: "DTFF Support"
-    weight: 20
+    weight: 45
 
 layout: services
 


### PR DESCRIPTION
### Motivation
- Ensure the `AI for Business Workshops` and `DTFF Support` pages appear after Grover’s Algorithm Guide (weight `42`) and before Contact Us (weight `50`) in the main navigation.

### Description
- Updated `menu.main.weight` in `content/aiforbusiness/_index.md` from `10` to `44` and in `content/dtff/_index.md` from `20` to `45` to position these entries after the Grover’s Algorithm Guide.

### Testing
- No automated tests were run because this is a content-only change; site build or visual verification was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e66644ef08320a8dc740346f82577)