### PR TITLE
Add text-only product partial and CSS modifier

### DIFF
--- a/assets/sass/_products.scss
+++ b/assets/sass/_products.scss
@@ -26,6 +26,11 @@
         width: 100%;
       }
     }
+    &.text-only{
+      .left{
+        width: 100%;
+      }
+    }
     .right{
       flex: 1;
       @media screen and (max-width:960px) {

--- a/layouts/partials/product-text.html
+++ b/layouts/partials/product-text.html
@@ -1,0 +1,16 @@
+<section class="product_products text-light" {{with .ctx.bg_color}} {{printf "style='background-color:%s;'" . | safeHTMLAttr}} {{end}}>
+  <div class="container mx-auto">
+    <div style="{{if .ctx.reverse}}flex-direction: row-reverse;{{end}}" class="product-wrapper text-only">
+      <div class="left">
+        <h2 id="{{.ctx.heading | urlize}}" style="color: #B9DCD5;">{{.ctx.heading}}</h2>
+        {{ with .ctx.subheading }}
+          <h4>{{ . }}</h4>
+        {{ end }}
+        {{ index (split .content "<hr>") .ctx.order | markdownify }}
+        <div class="mt-2">
+          <a class="btn-underlined" href="{{.ctx.cta_link}}">{{.ctx.cta}}</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
### Motivation
- Provide a text-only variant of the product section that removes the image column but preserves the same markup and authoring pattern as `/products`.
- Ensure the left content column spans the full width when the right image column is absent so styling remains consistent.

### Description
- Added `layouts/partials/product-text.html` which mirrors `product.html` but removes the `.right` image column and still renders `heading`, optional `subheading`, and `{{ index (split .content "<hr>") .ctx.order | markdownify }}` for the section body.
- Kept the outer wrapper classes `product_products` and `product-wrapper` and applied a `text-only` class to the wrapper in the new partial.
- Updated `assets/sass/_products.scss` to include a `&.text-only { .left { width: 100%; } }` rule so the left column becomes full width when the `text-only` modifier is present.

### Testing
- Attempted to run `hugo version` to verify build tooling but the command failed because `hugo` is not available in the environment.
- No automated build or other tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6fef90b88320b43c4f0841d53a0f)