### PR TITLE
Set canonical URL and add redirect alias for photonics service page

### DIFF
--- a/content/services/scientific-software-simulation-photonics/_index.md
+++ b/content/services/scientific-software-simulation-photonics/_index.md
@@ -3,7 +3,8 @@ title: "Scientific Software & Simulation for Photonics"
 description: "Scientific software and simulation support for photonics and semiconductor engineering, spanning physics-based modelling, HPC workflows, and cloud-native platforms."
 date: 2025-01-18T00:00:00Z
 draft: false
-aliases: ['/simulation']
+url: "/scientific-software-simulation-photonics/"
+aliases: ['/simulation', '/services/scientific-software-simulation-photonics/']
 sections:
   - type: hero_products
     heading: "Scientific software and simulation for photonics and semiconductor engineering"


### PR DESCRIPTION
### Motivation
- Ensure the photonics service page is served from a canonical root URL while preserving existing links to the previous `/services/...` path as redirects.

### Description
- Add `url: "/scientific-software-simulation-photonics/"` and append `'/services/scientific-software-simulation-photonics/'` to `aliases` in `content/services/scientific-software-simulation-photonics/_index.md`.

### Testing
- Content-only change; no automated tests were run and a site build was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7fd80af48320b6d2f8058feca416)