### PR TITLE
Add TRL Level Identifier quiz (layout, engine, styles, content)

### DIFF
--- a/assets/sass/_trl-quiz.scss
+++ b/assets/sass/_trl-quiz.scss
@@ -1,0 +1,263 @@
+.trl-quiz-page {
+  .trl-quiz-hero {
+    background-color: #F1F7F5;
+    padding: 4rem 2rem 3rem;
+    text-align: center;
+
+    h1 {
+      margin-bottom: 0.8rem;
+      color: #334B4E;
+    }
+
+    .trl-quiz-intro {
+      max-width: 760px;
+      margin: 0 auto 1.2rem;
+      color: #333;
+      line-height: 1.7;
+    }
+
+    .trl-quiz-meta {
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+    }
+
+    .trl-pill {
+      display: inline-flex;
+      align-items: center;
+      background: #fff;
+      border: 1px solid #9BCCC1;
+      color: #334B4E;
+      border-radius: 999px;
+      font-size: 0.8rem;
+      font-weight: 600;
+      padding: 0.35rem 0.8rem;
+    }
+  }
+
+  .trl-quiz-app {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 2.5rem 2rem 5rem;
+  }
+
+  .trl-progress {
+    margin-bottom: 1.5rem;
+
+    .trl-progress-bar {
+      width: 100%;
+      height: 10px;
+      background: #E8E8E8;
+      border-radius: 999px;
+      overflow: hidden;
+    }
+
+    .trl-progress-fill {
+      width: 0;
+      height: 100%;
+      border-radius: 999px;
+      background: linear-gradient(90deg, #9BCCC1 0%, #334B4E 100%);
+      transition: width 0.25s ease;
+    }
+
+    .trl-progress-text {
+      margin-top: 0.6rem;
+      text-align: center;
+      color: #666;
+      font-size: 0.95rem;
+    }
+  }
+
+  .trl-quiz-content {
+    .trl-question-card,
+    .trl-result-card {
+      background: #fff;
+      border: 1px solid #E8E8E8;
+      border-radius: 14px;
+      padding: 1.5rem;
+      box-shadow: 0 6px 24px rgba(51, 75, 78, 0.08);
+    }
+
+    h2 {
+      color: #334B4E;
+      margin: 0 0 0.8rem;
+    }
+
+    .trl-question-description,
+    .trl-result-summary {
+      color: #555;
+      line-height: 1.6;
+      margin-bottom: 1rem;
+    }
+
+    .trl-options {
+      display: grid;
+      gap: 0.8rem;
+      margin-top: 1rem;
+    }
+
+    .trl-option {
+      border: 2px solid #E8E8E8;
+      background: #fff;
+      border-radius: 10px;
+      text-align: left;
+      padding: 0.95rem 1rem;
+      color: #334B4E;
+      cursor: pointer;
+      transition: border-color 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
+      font-family: inherit;
+      font-weight: 600;
+
+      &:hover,
+      &:focus-visible {
+        border-color: #9BCCC1;
+        background: #F9FCFB;
+        transform: translateY(-1px);
+        outline: none;
+      }
+    }
+
+    .trl-result-header {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      margin-bottom: 0.8rem;
+
+      .trl-result-level {
+        margin: 0;
+        background: #334B4E;
+        color: #fff;
+        padding: 0.35rem 0.8rem;
+        border-radius: 999px;
+        font-weight: 700;
+        white-space: nowrap;
+      }
+
+      h2 {
+        margin: 0;
+      }
+    }
+
+    h3 {
+      margin-top: 1.2rem;
+      color: #334B4E;
+    }
+
+    ul {
+      margin: 0.5rem 0 0;
+      padding-left: 1.25rem;
+
+      li {
+        margin-bottom: 0.4rem;
+        color: #444;
+      }
+    }
+
+    .trl-actions {
+      margin-top: 1.5rem;
+      display: flex;
+      gap: 0.8rem;
+      justify-content: flex-end;
+      flex-wrap: wrap;
+
+      .btn-secondary {
+        background: transparent;
+        color: #334B4E;
+        border: 2px solid #334B4E;
+        border-radius: 999px;
+        padding: 0.55rem 1.1rem;
+        cursor: pointer;
+        font-family: inherit;
+        font-weight: 600;
+
+        &:hover,
+        &:focus-visible {
+          background: #F1F7F5;
+          outline: none;
+        }
+
+        &:disabled {
+          opacity: 0.45;
+          cursor: not-allowed;
+        }
+      }
+    }
+  }
+
+  .trl-scale-reference {
+    margin-top: 1.2rem;
+    border: 1px solid #E8E8E8;
+    border-radius: 12px;
+    overflow: hidden;
+
+    .trl-scale-toggle {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border: 0;
+      background: #F9FCFB;
+      color: #334B4E;
+      font-weight: 700;
+      padding: 0.95rem 1.1rem;
+      text-align: left;
+      cursor: pointer;
+      font-family: inherit;
+
+      .trl-scale-icon {
+        transition: transform 0.2s ease;
+      }
+
+      &[aria-expanded='true'] .trl-scale-icon {
+        transform: rotate(180deg);
+      }
+    }
+
+    .trl-scale-panel {
+      padding: 0.9rem 1.1rem 0.8rem;
+      background: #fff;
+
+      ul {
+        margin: 0;
+        padding-left: 1.1rem;
+      }
+
+      li {
+        margin-bottom: 0.35rem;
+        color: #444;
+      }
+    }
+  }
+
+  @media screen and (max-width: 700px) {
+    .trl-quiz-hero {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+
+    .trl-quiz-app {
+      padding: 1.6rem 1rem 3rem;
+    }
+
+    .trl-quiz-content {
+      .trl-question-card,
+      .trl-result-card {
+        padding: 1.1rem;
+      }
+
+      .trl-result-header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .trl-actions {
+        justify-content: stretch;
+
+        .btn-secondary {
+          width: 100%;
+        }
+      }
+    }
+  }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -14,3 +14,4 @@
 @import 'services';
 @import 'single';
 @import 'quiz';
+@import 'trl-quiz';

--- a/content/trl-identifier/_index.md
+++ b/content/trl-identifier/_index.md
@@ -1,0 +1,9 @@
+---
+title: "TRL Level Identifier"
+layout: trl
+draft: false
+---
+
+Use this quick Technology Readiness Level (TRL) identifier to estimate where your innovation currently sits, from early concept through operational deployment.
+
+The tool asks a short sequence of practical, evidence-led questions and then maps your responses to a likely TRL band. You can restart at any time, compare pathways, and use the scale reference to align your internal assessment language.

--- a/layouts/_default/trl.html
+++ b/layouts/_default/trl.html
@@ -1,0 +1,62 @@
+{{ define "main" }}
+{{ partial "nav-new.html" . }}
+
+<div class="trl-quiz-page">
+  <main class="trl-quiz-main">
+    <section class="trl-quiz-hero">
+      <div class="container mx-auto">
+        <h1>{{ .Title }}</h1>
+        <p class="trl-quiz-intro">{{ .Content }}</p>
+        <div class="trl-quiz-meta" aria-label="Tool metadata">
+          <span class="trl-pill">ISMS Tool</span>
+          <span class="trl-pill">Decision Tree</span>
+          <span class="trl-pill">5–8 Minutes</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="trl-quiz-app" id="trl-quiz-app">
+      <div class="trl-progress" aria-label="Assessment progress">
+        <div class="trl-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+          <div class="trl-progress-fill" id="progress-fill"></div>
+        </div>
+        <p class="trl-progress-text">
+          Step <span id="progress-step">1</span> of <span id="progress-total">7</span>
+        </p>
+      </div>
+
+      <div class="trl-quiz-content" id="trl-quiz-content" aria-live="polite"></div>
+
+      <section class="trl-scale-reference" aria-labelledby="trl-scale-heading">
+        <button
+          class="trl-scale-toggle"
+          id="trl-scale-toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="trl-scale-panel"
+        >
+          <span id="trl-scale-heading">Technology Readiness Level Scale Reference</span>
+          <span class="trl-scale-icon" aria-hidden="true">▾</span>
+        </button>
+        <div class="trl-scale-panel" id="trl-scale-panel" hidden>
+          <ul>
+            <li><strong>TRL 1</strong> – Basic principles observed.</li>
+            <li><strong>TRL 2</strong> – Technology concept formulated.</li>
+            <li><strong>TRL 3</strong> – Experimental proof of concept.</li>
+            <li><strong>TRL 4</strong> – Validation in laboratory environment.</li>
+            <li><strong>TRL 5</strong> – Validation in relevant environment.</li>
+            <li><strong>TRL 6</strong> – Prototype demonstrated in relevant environment.</li>
+            <li><strong>TRL 7</strong> – System prototype demonstrated in operational setting.</li>
+            <li><strong>TRL 8</strong> – System complete and qualified.</li>
+            <li><strong>TRL 9</strong> – Actual system proven in mission operations.</li>
+          </ul>
+        </div>
+      </section>
+    </section>
+  </main>
+</div>
+
+{{ partial "footer-new.html" . }}
+
+<script src="/trl-quiz-engine.js"></script>
+{{ end }}

--- a/static/trl-quiz-engine.js
+++ b/static/trl-quiz-engine.js
@@ -1,0 +1,340 @@
+/**
+ * TRL Quiz Engine
+ * Decision-tree flow for Technology Readiness Level identification.
+ */
+
+(() => {
+  const questions = {
+    q1: {
+      title: 'Is the technology currently used in live operations?',
+      description: 'Consider whether this exact solution is already delivering outcomes in its intended operational environment.',
+      options: [
+        { label: 'Yes, in routine live use', next: 'r_9' },
+        { label: 'Not yet', next: 'q2' }
+      ]
+    },
+    q2: {
+      title: 'Is there a complete, integrated system that has passed qualification tests?',
+      description: 'Qualification includes formal verification against performance and safety requirements.',
+      options: [
+        { label: 'Yes, complete and qualified', next: 'r_8' },
+        { label: 'Partially complete or still maturing', next: 'q3' }
+      ]
+    },
+    q3: {
+      title: 'Has a prototype been demonstrated in an operational setting?',
+      description: 'Operational setting means realistic users, constraints, and workflows.',
+      options: [
+        { label: 'Yes, demonstrated in operations', next: 'r_7' },
+        { label: 'No, only in controlled or limited environments', next: 'q3b' }
+      ]
+    },
+    q3b: {
+      title: 'Has a prototype been demonstrated in a relevant (but not full operational) environment?',
+      description: 'Relevant environments can include pilot lines, testbeds, and representative field conditions.',
+      options: [
+        { label: 'Yes, demonstrated in relevant environment', next: 'r_6' },
+        { label: 'No, still in earlier validation', next: 'q4' }
+      ]
+    },
+    q4: {
+      title: 'Has the technology been validated in a relevant environment with representative components?',
+      description: 'Validation typically includes integrated components and measured performance evidence.',
+      options: [
+        { label: 'Yes', next: 'r_5' },
+        { label: 'No', next: 'q5' }
+      ]
+    },
+    q5: {
+      title: 'Do you have experimental proof-of-concept results?',
+      description: 'Proof-of-concept means data showing that key technical assumptions hold under test.',
+      options: [
+        { label: 'Yes, with test evidence', next: 'r_3' },
+        { label: 'No, still mostly conceptual', next: 'q4b' }
+      ]
+    },
+    q4b: {
+      title: 'Has the concept been formally defined with identified principles and use case?',
+      description: 'If not, the work is likely pre-formulation and at the earliest maturity stage.',
+      options: [
+        { label: 'Concept and principles are identified', next: 'r_3' },
+        { label: 'Not yet formally defined', next: 'r_1' }
+      ]
+    }
+  };
+
+  const results = {
+    r_na: {
+      level: 'N/A',
+      heading: 'Insufficient evidence to place a TRL confidently',
+      summary: 'Capture clearer technical evidence before assigning a readiness level.',
+      nextSteps: [
+        'Document what has and has not been tested.',
+        'Define intended operational context and success criteria.',
+        'Run a structured review with engineering and delivery stakeholders.'
+      ]
+    },
+    r_9: {
+      level: 'TRL 9',
+      heading: 'Actual system proven in operational use',
+      summary: 'Your technology appears to be fully mature and operating in real-world conditions.',
+      nextSteps: [
+        'Track reliability and performance over time.',
+        'Capture lessons learned for scaling or transfer.',
+        'Use operational evidence to support assurance and procurement activities.'
+      ]
+    },
+    r_8: {
+      level: 'TRL 8',
+      heading: 'System complete and qualified',
+      summary: 'The system is complete and qualification evidence is in place, but full operational use may still be limited.',
+      nextSteps: [
+        'Plan controlled operational rollout.',
+        'Validate handover and support arrangements.',
+        'Close any remaining acceptance actions before full deployment.'
+      ]
+    },
+    r_7: {
+      level: 'TRL 7',
+      heading: 'Prototype demonstrated in operational setting',
+      summary: 'You have strong real-context evidence, with work remaining before full qualification and deployment.',
+      nextSteps: [
+        'Harden the prototype into a production-ready system.',
+        'Complete qualification and compliance testing.',
+        'Prepare detailed deployment and risk controls.'
+      ]
+    },
+    r_6: {
+      level: 'TRL 6',
+      heading: 'Prototype demonstrated in relevant environment',
+      summary: 'The concept has moved beyond lab validation and shown capability in representative conditions.',
+      nextSteps: [
+        'Expand trials into operationally realistic conditions.',
+        'Address integration constraints and edge cases.',
+        'Build evidence package for operational demonstration.'
+      ]
+    },
+    r_5: {
+      level: 'TRL 5',
+      heading: 'Technology validated in relevant environment',
+      summary: 'Validation evidence exists, but demonstration maturity should increase before operational pilots.',
+      nextSteps: [
+        'Increase system integration depth.',
+        'Define operational pilot success metrics.',
+        'Develop transition plan toward demonstrator readiness.'
+      ]
+    },
+    r_3: {
+      level: 'TRL 3',
+      heading: 'Experimental proof of concept stage',
+      summary: 'You have early evidence for feasibility, but significant validation and engineering remain.',
+      nextSteps: [
+        'Strengthen experimental protocol and repeatability.',
+        'Prioritize key technical risks and assumptions.',
+        'Design pathway into lab and relevant-environment validation.'
+      ]
+    },
+    r_1: {
+      level: 'TRL 1',
+      heading: 'Basic principles stage',
+      summary: 'Work is at the foundational discovery phase with limited formal concept definition.',
+      nextSteps: [
+        'Document core scientific or technical principles.',
+        'Frame potential use cases and constraints.',
+        'Define first experiments to establish feasibility evidence.'
+      ]
+    }
+  };
+
+  const totalSteps = 7;
+  let currentId = 'q1';
+  let history = [];
+
+  const contentEl = document.getElementById('trl-quiz-content');
+  const progressFillEl = document.getElementById('progress-fill');
+  const progressStepEl = document.getElementById('progress-step');
+  const progressTotalEl = document.getElementById('progress-total');
+
+  if (!contentEl) return;
+
+  if (progressTotalEl) {
+    progressTotalEl.textContent = String(totalSteps);
+  }
+
+  function escapeHtml(text) {
+    return String(text)
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#039;');
+  }
+
+  function renderQuestion(questionId) {
+    const question = questions[questionId];
+
+    if (!question) {
+      renderResult('r_na');
+      return;
+    }
+
+    currentId = questionId;
+
+    const optionButtons = question.options
+      .map((option) => (
+        `<button type="button" class="trl-option" data-next-id="${escapeHtml(option.next)}">${escapeHtml(option.label)}</button>`
+      ))
+      .join('');
+
+    contentEl.innerHTML = `
+      <article class="trl-question-card">
+        <h2>${escapeHtml(question.title)}</h2>
+        <p class="trl-question-description">${escapeHtml(question.description)}</p>
+        <div class="trl-options">${optionButtons}</div>
+        <div class="trl-actions">
+          <button type="button" class="btn-secondary" data-action="back" ${history.length === 0 ? 'disabled' : ''}>Back</button>
+          <button type="button" class="btn-secondary" data-action="restart">Restart</button>
+        </div>
+      </article>
+    `;
+
+    contentEl.querySelectorAll('[data-next-id]').forEach((button) => {
+      button.addEventListener('click', () => choose(button.dataset.nextId));
+    });
+
+    const backButton = contentEl.querySelector('[data-action="back"]');
+    const restartButton = contentEl.querySelector('[data-action="restart"]');
+
+    if (backButton) {
+      backButton.addEventListener('click', goBack);
+    }
+
+    if (restartButton) {
+      restartButton.addEventListener('click', restart);
+    }
+
+    const step = Math.min(history.length + 1, totalSteps);
+    const pct = (step / totalSteps) * 100;
+    updateProgress(pct, step);
+  }
+
+  function renderResult(resultId) {
+    const result = results[resultId] || results.r_na;
+    currentId = resultId;
+
+    const nextStepsList = result.nextSteps
+      .map((item) => `<li>${escapeHtml(item)}</li>`)
+      .join('');
+
+    contentEl.innerHTML = `
+      <article class="trl-result-card">
+        <header class="trl-result-header">
+          <p class="trl-result-level">${escapeHtml(result.level)}</p>
+          <h2>${escapeHtml(result.heading)}</h2>
+        </header>
+        <p class="trl-result-summary">${escapeHtml(result.summary)}</p>
+        <h3>Recommended next actions</h3>
+        <ul>${nextStepsList}</ul>
+        <div class="trl-actions">
+          <button type="button" class="btn-secondary" data-action="back" ${history.length === 0 ? 'disabled' : ''}>Back</button>
+          <button type="button" class="btn-secondary" data-action="restart">Restart assessment</button>
+        </div>
+      </article>
+    `;
+
+    const backButton = contentEl.querySelector('[data-action="back"]');
+    const restartButton = contentEl.querySelector('[data-action="restart"]');
+
+    if (backButton) {
+      backButton.addEventListener('click', goBack);
+    }
+
+    if (restartButton) {
+      restartButton.addEventListener('click', restart);
+    }
+
+    const step = Math.min(history.length + 1, totalSteps);
+    updateProgress(100, step);
+  }
+
+  function choose(nextId) {
+    history.push(currentId);
+
+    if (nextId && nextId.startsWith('q')) {
+      renderQuestion(nextId);
+      return;
+    }
+
+    renderResult(nextId);
+  }
+
+  function goBack() {
+    if (history.length === 0) {
+      return;
+    }
+
+    const previousId = history.pop();
+
+    if (previousId.startsWith('q')) {
+      renderQuestion(previousId);
+      return;
+    }
+
+    renderResult(previousId);
+  }
+
+  function restart() {
+    history = [];
+    currentId = 'q1';
+    renderQuestion('q1');
+  }
+
+  function updateProgress(pct, step) {
+    if (progressFillEl) {
+      progressFillEl.style.width = `${pct}%`;
+      const progressBar = progressFillEl.closest('[role="progressbar"]');
+      if (progressBar) {
+        progressBar.setAttribute('aria-valuenow', String(Math.round(pct)));
+      }
+    }
+
+    if (progressStepEl) {
+      progressStepEl.textContent = String(step);
+    }
+  }
+
+  function setupAccordion() {
+    const toggle = document.getElementById('trl-scale-toggle');
+    const panel = document.getElementById('trl-scale-panel');
+
+    if (!toggle || !panel) {
+      return;
+    }
+
+    const togglePanel = () => {
+      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', String(!isExpanded));
+      panel.hidden = isExpanded;
+    };
+
+    toggle.addEventListener('click', togglePanel);
+    toggle.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        togglePanel();
+      }
+    });
+  }
+
+  setupAccordion();
+  renderQuestion('q1');
+
+  window.trlQuizEngine = {
+    renderQuestion,
+    renderResult,
+    choose,
+    goBack,
+    restart,
+    updateProgress
+  };
+})();


### PR DESCRIPTION
### Motivation

- Provide an interactive Technology Readiness Level (TRL) identifier tool to help users map their innovation to an appropriate TRL band via a short decision-tree assessment.

### Description

- Add a client-side quiz engine at `static/trl-quiz-engine.js` implementing the decision-tree flow, navigation (back/restart), progress updates, and an accessible scale accordion.
- Add a page layout `layouts/_default/trl.html` that renders the quiz, progress bar, scale reference, and loads the quiz engine script.
- Add styles in `assets/sass/_trl-quiz.scss` and import it from `assets/sass/style.scss` to style the quiz components, responsive rules, and UI states.
- Add the content entry `content/trl-identifier/_index.md` to expose the TRL Identifier page and basic tool description.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd3d5e1ff08320b19d53b3b801c610)