### PR TITLE
Update TRL hero copy and metadata pills

### DIFF
--- a/content/trl-identifier/_index.md
+++ b/content/trl-identifier/_index.md
@@ -4,6 +4,6 @@ layout: trl
 draft: false
 ---
 
-Use this quick Technology Readiness Level (TRL) identifier to estimate where your innovation currently sits, from early concept through operational deployment.
+Answer a few questions to identify your current Technology Readiness Level (TRL) for internal ISMS use.
 
-The tool asks a short sequence of practical, evidence-led questions and then maps your responses to a likely TRL band. You can restart at any time, compare pathways, and use the scale reference to align your internal assessment language.
+This tool is for team and internal usage only, to support consistent internal assessment and discussion.

--- a/layouts/_default/trl.html
+++ b/layouts/_default/trl.html
@@ -8,9 +8,9 @@
         <h1>{{ .Title }}</h1>
         <p class="trl-quiz-intro">{{ .Content }}</p>
         <div class="trl-quiz-meta" aria-label="Tool metadata">
-          <span class="trl-pill">ISMS Tool</span>
-          <span class="trl-pill">Decision Tree</span>
-          <span class="trl-pill">5–8 Minutes</span>
+          <span class="trl-pill">5 questions</span>
+          <span class="trl-pill">~2 minutes</span>
+          <span class="trl-pill">Internal use · ISMS</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Align the TRL hero and intro copy with the supplied HTML so the page uses internal ISMS framing, the exact “Answer a few questions…” wording, and team/internal usage language, and present the requested metadata pills.

### Description
- Updated `content/trl-identifier/_index.md` to set the hero/subheading body to: "Answer a few questions to identify your current Technology Readiness Level (TRL) for internal ISMS use." and "This tool is for team and internal usage only, to support consistent internal assessment and discussion.", and updated `layouts/_default/trl.html` to replace the hero metadata pills with `5 questions`, `~2 minutes`, and `Internal use · ISMS`.

### Testing
- Verified the changes with `git diff -- content/trl-identifier/_index.md layouts/_default/trl.html` and confirmed the working tree with `git status --short`, both showing the intended edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd4228894c8320ab50ba3ff25e3310)