### PR TITLE
Align TRL quiz progress UI to 5-question branching flow

### DIFF
--- a/layouts/_default/trl.html
+++ b/layouts/_default/trl.html
@@ -20,9 +20,7 @@
         <div class="trl-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
           <div class="trl-progress-fill" id="progress-fill"></div>
         </div>
-        <p class="trl-progress-text">
-          Step <span id="progress-step">1</span> of <span id="progress-total">7</span>
-        </p>
+        <p class="trl-progress-text" id="progress-step">Question 1 of 5</p>
       </div>
 
       <div class="trl-quiz-content" id="trl-quiz-content" aria-live="polite"></div>

--- a/static/trl-quiz-engine.js
+++ b/static/trl-quiz-engine.js
@@ -146,20 +146,15 @@
     }
   };
 
-  const totalSteps = 7;
+  const totalQuestions = 5;
   let currentId = 'q1';
   let history = [];
 
   const contentEl = document.getElementById('trl-quiz-content');
   const progressFillEl = document.getElementById('progress-fill');
   const progressStepEl = document.getElementById('progress-step');
-  const progressTotalEl = document.getElementById('progress-total');
 
   if (!contentEl) return;
-
-  if (progressTotalEl) {
-    progressTotalEl.textContent = String(totalSteps);
-  }
 
   function escapeHtml(text) {
     return String(text)
@@ -213,9 +208,10 @@
       restartButton.addEventListener('click', restart);
     }
 
-    const step = Math.min(history.length + 1, totalSteps);
-    const pct = (step / totalSteps) * 100;
-    updateProgress(pct, step);
+    const questionNumberMap = { q1: 1, q2: 2, q3: 3, q3b: 3, q4: 4, q5: 5, q4b: 5 };
+    const questionNumber = questionNumberMap[questionId] || 1;
+    const pct = (questionNumber / totalQuestions) * 100;
+    updateProgress(pct, `Question ${questionNumber} of ${totalQuestions}`);
   }
 
   function renderResult(resultId) {
@@ -253,8 +249,7 @@
       restartButton.addEventListener('click', restart);
     }
 
-    const step = Math.min(history.length + 1, totalSteps);
-    updateProgress(100, step);
+    updateProgress(100, "Done \u00b7 Result");
   }
 
   function choose(nextId) {
@@ -289,7 +284,7 @@
     renderQuestion('q1');
   }
 
-  function updateProgress(pct, step) {
+  function updateProgress(pct, label) {
     if (progressFillEl) {
       progressFillEl.style.width = `${pct}%`;
       const progressBar = progressFillEl.closest('[role="progressbar"]');
@@ -299,7 +294,7 @@
     }
 
     if (progressStepEl) {
-      progressStepEl.textContent = String(step);
+      progressStepEl.textContent = label;
     }
   }
 


### PR DESCRIPTION
### Motivation

- Make the on-page progress label and progress-bar behaviour match the intended 5-question branching flow and the UX language "Question X of 5" then "Done · Result" on completion.  
- Preserve the quiz navigation semantics (Back / Restart) and the existing decision-tree IDs/targets so downstream wiring and storage remain unchanged.  
- The requested replacement of `questions`/`results` with an external HTML `<script>` block was not performed because that script block was not available in the workspace at the time of changes.

### Description

- Replaced the multi-element progress markup in `layouts/_default/trl.html` with a single dynamic label initialized as `Question 1 of 5`.  
- Updated `static/trl-quiz-engine.js` to use `const totalQuestions = 5`, added an explicit `questionNumberMap` for branch nodes (`q3b` → 3, `q4b` → 5), and compute a percentage for the progress fill from the mapped question number.  
- Changed the progress API to `updateProgress(pct, label)` and render `Question X of 5` during questions and `Done · Result` for result screens.  
- Kept all quiz IDs and branch targets (`q1,q2,q3,q3b,q4,q5,q4b` and `r_na,r_9,r_8,r_7,r_6,r_5,r_3,r_1`) and preserved `Back`/`Restart` behaviour and result rendering logic unchanged, and did not modify the `questions`/`results` objects because the source HTML script was not provided.

### Testing

- Ran a syntax check on the modified script with `node -c static/trl-quiz-engine.js`, which completed successfully.  
- Verified removal of legacy identifiers and the new progress labeling using `rg`/search checks for `totalSteps`/`progress-total` and for `Question X of`/`Done`, which returned expected results.  
- No automated browser rendering tests were run in this environment, so visual verification in a browser is recommended as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd42b947108320ac3ad52ddc494d94)