### PR TITLE
Update TRL scale accordion to row-based TRL 0–9 reference

### DIFF
--- a/assets/sass/_trl-quiz.scss
+++ b/assets/sass/_trl-quiz.scss
@@ -218,14 +218,63 @@
       padding: 0.9rem 1.1rem 0.8rem;
       background: #fff;
 
-      ul {
-        margin: 0;
-        padding-left: 1.1rem;
+      .trl-scale-table {
+        display: flex;
+        flex-direction: column;
+        border: 1px solid #e8eceb;
+        border-radius: 10px;
+        overflow: hidden;
       }
 
-      li {
-        margin-bottom: 0.35rem;
-        color: #444;
+      .trl-scale-row {
+        display: grid;
+        grid-template-columns: minmax(88px, 0.9fr) minmax(0, 2.6fr) minmax(130px, 1fr);
+        gap: 0.8rem;
+        align-items: start;
+        padding: 0.65rem 0.75rem;
+        color: #334b4e;
+        border-bottom: 1px solid #edf1f0;
+
+        &:last-child {
+          border-bottom: 0;
+        }
+      }
+
+      .trl-scale-row--header {
+        background: #f7fbfa;
+        font-weight: 700;
+      }
+
+      .trl-scale-level {
+        font-weight: 700;
+      }
+
+      .trl-scale-scope {
+        font-weight: 600;
+      }
+
+      .trl-scale-scope--in {
+        color: #1f7a45;
+      }
+
+      .trl-scale-scope--case {
+        color: #8a6a00;
+      }
+
+      .trl-scale-scope--out,
+      .trl-scale-scope--out-star {
+        color: #8d1f1f;
+      }
+
+      @media screen and (max-width: 700px) {
+        .trl-scale-row {
+          grid-template-columns: 1fr;
+          gap: 0.3rem;
+        }
+
+        .trl-scale-row--header {
+          display: none;
+        }
       }
     }
   }

--- a/layouts/_default/trl.html
+++ b/layouts/_default/trl.html
@@ -37,17 +37,68 @@
           <span class="trl-scale-icon" aria-hidden="true">▾</span>
         </button>
         <div class="trl-scale-panel" id="trl-scale-panel" hidden>
-          <ul>
-            <li><strong>TRL 1</strong> – Basic principles observed.</li>
-            <li><strong>TRL 2</strong> – Technology concept formulated.</li>
-            <li><strong>TRL 3</strong> – Experimental proof of concept.</li>
-            <li><strong>TRL 4</strong> – Validation in laboratory environment.</li>
-            <li><strong>TRL 5</strong> – Validation in relevant environment.</li>
-            <li><strong>TRL 6</strong> – Prototype demonstrated in relevant environment.</li>
-            <li><strong>TRL 7</strong> – System prototype demonstrated in operational setting.</li>
-            <li><strong>TRL 8</strong> – System complete and qualified.</li>
-            <li><strong>TRL 9</strong> – Actual system proven in mission operations.</li>
-          </ul>
+          <div class="trl-scale-table" role="table" aria-label="Technology Readiness Level scale">
+            <div class="trl-scale-row trl-scale-row--header" role="row">
+              <span role="columnheader">Level</span>
+              <span role="columnheader">Description</span>
+              <span role="columnheader">Scope</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">N/A</span>
+              <span role="cell">Consultancy, mentorship, and advisory support without direct technology development.</span>
+              <span class="trl-scale-scope trl-scale-scope--out-star" role="cell">Out of scope*</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 0</span>
+              <span role="cell">Pre-TRL activity where a problem is identified and framed, but no scientific or technical work has yet started.</span>
+              <span class="trl-scale-scope trl-scale-scope--out" role="cell">Out of scope</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 1</span>
+              <span role="cell">Basic principles observed and reported through initial scientific research.</span>
+              <span class="trl-scale-scope trl-scale-scope--out" role="cell">Out of scope</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 2</span>
+              <span role="cell">Technology concept and/or application formulated with potential use cases identified.</span>
+              <span class="trl-scale-scope trl-scale-scope--out" role="cell">Out of scope</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 3</span>
+              <span role="cell">Analytical and experimental proof of concept established through early validation work.</span>
+              <span class="trl-scale-scope trl-scale-scope--case" role="cell">Case-by-case</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 4</span>
+              <span role="cell">Technology validated in a laboratory environment using integrated components.</span>
+              <span class="trl-scale-scope trl-scale-scope--case" role="cell">Case-by-case</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 5</span>
+              <span role="cell">Technology validated in a relevant environment that reflects real-world conditions.</span>
+              <span class="trl-scale-scope trl-scale-scope--in" role="cell">In scope</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 6</span>
+              <span role="cell">Technology demonstrated as a prototype in a relevant environment.</span>
+              <span class="trl-scale-scope trl-scale-scope--in" role="cell">In scope</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 7</span>
+              <span role="cell">System prototype demonstrated in an operational environment.</span>
+              <span class="trl-scale-scope trl-scale-scope--in" role="cell">In scope</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 8</span>
+              <span role="cell">Actual system completed and qualified through test and demonstration.</span>
+              <span class="trl-scale-scope trl-scale-scope--in" role="cell">In scope</span>
+            </div>
+            <div class="trl-scale-row" role="row">
+              <span class="trl-scale-level" role="cell">TRL 9</span>
+              <span role="cell">Actual system proven through successful operation in mission conditions.</span>
+              <span class="trl-scale-scope trl-scale-scope--in" role="cell">In scope</span>
+            </div>
+          </div>
         </div>
       </section>
     </section>


### PR DESCRIPTION
### Motivation
- Replace the simple list in the TRL accordion with the supplied, exact scale content including an `N/A` row and TRL 0–9 descriptions. 
- Present the information in a 3-column, row-based layout (Level / Description / Scope) to match the TRL page CSS approach and support clearer scope labels.
- Preserve existing accordion accessibility and keyboard behavior so the toggle remains usable by assistive tech and keyboard users.

### Description
- Replaced the `<ul>` list in `layouts/_default/trl.html` with a row-based structure (`.trl-scale-table` / `.trl-scale-row`) containing `N/A` and `TRL 0`–`TRL 9` rows and exact description text and scope labels (`In scope`, `Out of scope`, `Case-by-case`, `Out of scope*`).
- Added `role` attributes for table semantics (`role="table"`, `role="row"`, `role="cell"`, `role="columnheader"`) to improve accessibility.
- Added minimal SCSS in `assets/sass/_trl-quiz.scss` for the new layout including grid columns for three-column desktop display, colours and scope label styles, header row styling, row separators, and a mobile fallback that collapses rows to a single column.
- Did not change existing accordion IDs/ARIA attributes or the JavaScript toggle logic, preserving `aria-expanded`, `aria-controls`, and the Enter/Space keyboard handling present in `static/trl-quiz-engine.js`.

### Testing
- Attempted an automated Hugo build with `hugo --panicOnWarning --printI18nWarnings --printPathWarnings --printUnusedTemplates`, but the command failed in this environment because `hugo` is not installed (no build executed).
- No other automated runtime tests were run; changes were validated by static inspection of the updated template and stylesheet to ensure the accordion hooks and script remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd44a3c8388320ad47984650caa740)