### PR TITLE
Fix dusk chapter navigation rendering and hero chapter links

### DIFF
--- a/static/internal/dusk/index.html
+++ b/static/internal/dusk/index.html
@@ -111,7 +111,7 @@ code {
   border-color: white;
 }
 .nav-dot[title]::after {
-  content: attr(title);
+  content: none;
 }
 #print-btn {
   background: rgba(255,255,255,0.15);
@@ -214,6 +214,12 @@ code {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  text-decoration: none;
+  transition: background 0.2s, border-color 0.2s;
+}
+.hero-chapter-item:hover {
+  background: rgba(255,255,255,0.16);
+  border-color: rgba(255,255,255,0.35);
 }
 .hero-chapter-item .num {
   width: 20px; height: 20px;
@@ -814,14 +820,14 @@ code {
       <span class="badge">📐 Wiring diagrams included</span>
     </div>
     <div class="hero-chapters">
-      <div class="hero-chapter-item"><div class="num">1</div> Prepare the Pi</div>
-      <div class="hero-chapter-item"><div class="num">2</div> Fit the HAT Mini</div>
-      <div class="hero-chapter-item"><div class="num">3</div> Temperature sensors</div>
-      <div class="hero-chapter-item"><div class="num">4</div> Wire the heaters</div>
-      <div class="hero-chapter-item"><div class="num">5</div> Wire the AC fan</div>
-      <div class="hero-chapter-item"><div class="num">6</div> Power supply</div>
-      <div class="hero-chapter-item"><div class="num">7</div> Install software</div>
-      <div class="hero-chapter-item"><div class="num">8</div> First test</div>
+      <a class="hero-chapter-item" href="#ch1"><div class="num">1</div> Prepare the Pi</a>
+      <a class="hero-chapter-item" href="#ch2"><div class="num">2</div> Fit the HAT Mini</a>
+      <a class="hero-chapter-item" href="#ch3"><div class="num">3</div> Temperature sensors</a>
+      <a class="hero-chapter-item" href="#ch4"><div class="num">4</div> Wire the heaters</a>
+      <a class="hero-chapter-item" href="#ch5"><div class="num">5</div> Wire the AC fan</a>
+      <a class="hero-chapter-item" href="#ch6"><div class="num">6</div> Power supply</a>
+      <a class="hero-chapter-item" href="#ch7"><div class="num">7</div> Install software</a>
+      <a class="hero-chapter-item" href="#ch8"><div class="num">8</div> First test</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- remove the unintended text rendering from top header chapter dots by disabling the pseudo-element content
- convert the hero chapter number tiles into anchor links so each numbered button jumps to its chapter
- add subtle hover styling for the hero chapter links to preserve button-like affordance

## Testing
- not run (static HTML/CSS update only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf8c4fd5848320beec561999b16d4a)