### PR TITLE
Make top header title clickable to return to page top

### DIFF
--- a/static/internal/dusk/index.html
+++ b/static/internal/dusk/index.html
@@ -791,7 +791,7 @@ code {
 
 <!-- Top Navigation -->
 <nav id="top-nav">
-  <span class="nav-title">🏠 Model House Build Guide</span>
+  <a class="nav-title" href="#" aria-label="Back to top">🏠 Model House Build Guide</a>
   <div class="nav-chapters" id="nav-chapters">
     <a class="nav-dot active" href="#safety" title="Safety"></a>
     <a class="nav-dot" href="#parts" title="Parts"></a>


### PR DESCRIPTION
## Summary
- Updated `static/internal/dusk/index.html` top navigation title from a non-interactive `<span>` to an anchor link.
- The header text `🏠 Model House Build Guide` now links to `#` so clicking it scrolls back to the top of the page.
- Added `aria-label="Back to top"` for accessibility context.

## Testing
- Static HTML change only; no runtime tests executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf8ec6b6e08320a55850caf5e08bd5)