### PR TITLE
Make top-nav title a clickable 'Back to top' link and suppress link underline

### DIFF
--- a/static/internal/dusk/index.html
+++ b/static/internal/dusk/index.html
@@ -91,6 +91,12 @@ code {
   font-weight: 600;
   color: white;
   white-space: nowrap;
+  text-decoration: none;
+}
+#top-nav .nav-title:hover,
+#top-nav .nav-title:focus,
+#top-nav .nav-title:active {
+  text-decoration: none;
 }
 #top-nav .nav-chapters {
   display: flex;
@@ -791,7 +797,7 @@ code {
 
 <!-- Top Navigation -->
 <nav id="top-nav">
-  <span class="nav-title">🏠 Model House Build Guide</span>
+  <a class="nav-title" href="#" aria-label="Back to top">🏠 Model House Build Guide</a>
   <div class="nav-chapters" id="nav-chapters">
     <a class="nav-dot active" href="#safety" title="Safety"></a>
     <a class="nav-dot" href="#parts" title="Parts"></a>


### PR DESCRIPTION
### Motivation
- Make the top navigation title focusable/clickable to provide a clear "back to top" affordance while keeping the visual style consistent with the rest of the nav.

### Description
- Modified `static/internal/dusk/index.html` to change the top-nav title from a `span` to an `a` element with `href="#"` and `aria-label="Back to top"`, and added CSS rules to set `text-decoration: none` on `.nav-title` and its `:hover`, `:focus`, and `:active` states to prevent underlines.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf8ec6b6e08320a55850caf5e08bd5)