### PR TITLE
Update Dusk guide styling and make top-nav title a clickable link

### DIFF
--- a/static/internal/dusk/index.html
+++ b/static/internal/dusk/index.html
@@ -77,7 +77,7 @@ code {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: var(--primary);
+  background: #213534;
   color: white;
   padding: 0.7rem 2rem;
   display: flex;
@@ -91,6 +91,12 @@ code {
   font-weight: 600;
   color: white;
   white-space: nowrap;
+  text-decoration: none;
+}
+#top-nav .nav-title:hover,
+#top-nav .nav-title:focus,
+#top-nav .nav-title:active {
+  text-decoration: none;
 }
 #top-nav .nav-chapters {
   display: flex;
@@ -125,7 +131,7 @@ code {
   font-weight: 600;
   transition: background 0.2s;
 }
-#print-btn:hover { background: rgba(255,255,255,0.25); }
+#print-btn:hover { background: rgba(252, 250, 247, 0.18); }
 
 /* ===== LAYOUT ===== */
 .container { max-width: 860px; margin: 0 auto; padding: 0 1.5rem; }
@@ -172,7 +178,7 @@ code {
 }
 #hero h1 em {
   font-style: italic;
-  color: #F0D080;
+  color: #D8BF8B;
 }
 .hero-sub {
   font-size: 1.1rem;
@@ -735,7 +741,7 @@ code {
   position: fixed;
   top: 0; left: 0;
   height: 3px;
-  background: #F0D080;
+  background: #D8BF8B;
   z-index: 200;
   transition: width 0.1s;
   pointer-events: none;
@@ -791,7 +797,7 @@ code {
 
 <!-- Top Navigation -->
 <nav id="top-nav">
-  <span class="nav-title">🏠 Model House Build Guide</span>
+  <a class="nav-title" href="#" aria-label="Back to top">🏠 Model House Build Guide</a>
   <div class="nav-chapters" id="nav-chapters">
     <a class="nav-dot active" href="#safety" title="Safety"></a>
     <a class="nav-dot" href="#parts" title="Parts"></a>
@@ -810,7 +816,7 @@ code {
 <!-- HERO -->
 <section id="hero">
   <div class="container">
-    <div class="hero-label">Project Dusk — Electronics Build Guide</div>
+    <div class="hero-label">Project Dusk - Electronics Build Guide</div>
     <h1>Your <em>step-by-step</em> guide to wiring the model house</h1>
     <p class="hero-sub">No electronics experience needed. Follow each chapter in order and you'll have a fully working sensor and control system — safely, neatly, and confidently.</p>
     <div class="hero-badges">


### PR DESCRIPTION
### Motivation

- Make the top navigation title actionable and accessible by converting it into a link and improving its focus/hover behavior.
- Improve contrast and visual consistency across the hero and progress elements by refining the color palette.
- Tidy minor UI details such as print button hover styling and consistent punctuation in the hero label.

### Description

- Convert the top navigation title from a `span` to an `a` with `href="#"` and `aria-label="Back to top"` and ensure `text-decoration: none` on normal and interactive states via CSS.
- Change the top navigation background to `#213534` for improved contrast and adjust the `#print-btn:hover` background to `rgba(252, 250, 247, 0.18)`.
- Update the hero emphasis color from `#F0D080` to `#D8BF8B` and the `#progress-bar` background to `#D8BF8B` to match the adjusted palette.
- Replace the hero label em-dash with a hyphen to normalize punctuation in the heading text.

### Testing

- Ran `npm run lint` to check CSS/HTML linting and the run completed successfully.
- Performed an automated site build with `npm run build` which completed without errors.
- Executed automated visual smoke tests (static rendering checks) which passed with no regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf8ec6b6e08320a55850caf5e08bd5)