### PR TITLE
Add Arches Work content page and pass page content into section partials

### DIFF
--- a/content/arches-work/_index.md
+++ b/content/arches-work/_index.md
@@ -1,0 +1,81 @@
+---
+title: "Arches Work"
+date: 2023-12-21T14:10:03Z
+aliases: ['/pages/arches-work']
+draft: false
+
+sections:
+  - type: l_r
+    img: '/images/arches-work/arches-transforming-your-data.webp'
+    order: 1
+    heading: "Arches - transforming your data"
+    bg_color: '#9BCCC1'
+    color: "#394E51"
+  - type: l_r
+    img: '/images/arches-work/arches-for-cultural-heritage.webp'
+    order: 2
+    heading: "Arches for Cultural Heritage"
+    bg_color: "#F6F4EB"
+    color: "#000"
+    reverse: true
+  - type: l_r
+    img: '/images/arches-work/arches-for-science.webp'
+    order: 3
+    heading: "Arches for Science"
+    bg_color: '#292929'
+    color: '#FFF'
+
+---
+
+---
+
+Arches is an open source data management platform which makes it possible for meaningful organisational change. Jointly funded by the World Monument Fund and the Getty Conservation Institute, it has evolved into a powerful asset management and GIS tool. <br><br>
+
+<strong>Why Flax & Teal?</strong>
+
+At Flax & Teal, we are more than just a software consultancy and IT solutions provider - we are passionate advocates for the preservation of cultural heritage. We aim to empower organisations worldwide to safeguard their invaluable heritage assets for future generations.<br><br>
+
+<strong> Registered Arches Suppliers</strong>
+
+Arches is revolutionising the way cultural heritage institutions manage, document, and share their collections. 
+
+We have conducted Arches workshops with the Arches team to build a roadmap for integrating the Arches software with modern DevOps flows, and are the leading team in doing so.
+
+As open source leaders, Arches naturally fits into our service expertise, we have run community events combining Arches platforms and Virtual Reality spaces, to push Arches’ technical capabilities.
+
+We have utilised Arches not only for large cultural heritage institutions, but for research-based organisations focused on data management.
+
+---
+
+**Digitally transforming cultural heritage**
+
+We are currently in the process of delivering a long-term digital transformation project for Northern Irish public sector, migrating all of their current and historic heritage-based data to a customised Arches HER (Historic Environment Record) instance. 
+
+They required a secure and accessible database capable of holding more than 200,000 records safely and without data loss. This has involved site visits, workshops and detailed data modelling exercises, and has been supported on the technology side by Kubernetes, Python-in-the-cloud, Ray data workflows and deployed to GKE. <br><br>
+
+  - **Kubernetes infrastructure flows**
+
+  - **Custom workflow development**
+
+  - **Custom dashboards for business processes**
+
+  - **Secure and stable development, staging and production instances** 
+
+  - **Hosting available on-premise or in cloud**
+<br><br>
+
+We're focused on helping large public sector organisations transform and manage their heritage data.
+
+---
+
+**Stable and secure data repository for researchers**
+
+We have deployed, and are currently hosting, Arches as a data repository for a large- scale international cross-disciplinary research project on urban policy (Tomorrow’s Cities).
+
+This involved interviewing a range of researchers, from social scientists to geologists, to establish a common base of requirements, and ensuring UKRI (UK Research and Innovation) compliant documentation and data management.
+
+Tomorrow’s Cities is being conducted with a range of institutions in Scotland, Nepal, Kenya and Turkey and, indirectly, governmental stakeholders to inform risk management for urban disaster planning globally.
+
+**Sustainable Open Source**
+
+Working closely with the London Science Museum, we developed and enhanced upon Arches' existing Bulk Data Manager module, allowing users to easily edit, flag and upload bulk data into their research database. We plan to integrate this work into the wider Arches codebase, and sustainably contribute to the open source development of the platform. 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -7,7 +7,7 @@
   {{ if eq .type "blog-list" }}
   {{ partial $partial (dict "section" . "page" $) }}
   {{ else }}
-  {{ partial $partial . }}
+  {{ partial $partial (dict "ctx" . "content" $.Content) }}
   {{ end }}
   {{ end }}
 </main>


### PR DESCRIPTION
### Motivation

- Introduce a new "Arches Work" content page describing services, case studies and technical details for the Arches platform.  
- Ensure section partials have access to the page body content so section templates can render inline content alongside section-specific params.  
- Improve layout rendering consistency when composing pages from `sections` front-matter.

### Description

- Added a new content page at `content/arches-work/_index.md` with front matter, multiple `sections` entries, and rich page body describing projects, infrastructure and contributions.  
- Updated `layouts/_default/list.html` to pass a dictionary into partials using `partial $partial (dict "ctx" . "content" $.Content)` so partials receive both the section context and the parent page content.  
- Maintained existing special-case handling for `blog-list` sections and preserved navigation/footer includes.

### Testing

- Built the site with `hugo --minify` and the build completed successfully with no template errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1805887a248320ab21336798c7eae9)